### PR TITLE
Introduce private and put_private

### DIFF
--- a/lib/context.ex
+++ b/lib/context.ex
@@ -41,6 +41,10 @@ defmodule FlowRunner.Context do
     parent_context: nil
   ]
 
+  @doc """
+  Clone a Context by its language & mode attributes, dropping everything else.
+  """
+  @spec clone_empty(t) :: t
   def clone_empty(%Context{language: language, mode: mode}) do
     %Context{language: language, mode: mode}
   end

--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -5,4 +5,14 @@ defmodule FlowRunner.ContextTest do
   test "put_private/3" do
     assert %Context{private: %{foo: "bar"}} == Context.put_private(%Context{}, :foo, "bar")
   end
+
+  test "clone_empty/1" do
+    assert %Context{language: "eng", mode: "TEXT"} ==
+             Context.clone_empty(%Context{
+               language: "eng",
+               mode: "TEXT",
+               vars: %{foo: "bar"},
+               private: %{foo: "bar"}
+             })
+  end
 end


### PR DESCRIPTION
Sometimes a FlowRunner.Context needs to have private variables that aren't able to be manipulated by Expressions.
An example is when a block needs to know information about accounts that it's processing things for.

In the case of a webhook, we'd want to know which entity owns a webhook. It would likely be stored as a UUID or something.
If we'd store that value in `context.vars` then an Expression could possibly overwrite that value and that would pose a potential security threat since then the Webhook execution is seeded with a wrong set of variables and giving access to organisation tokens that it's not supposed to have access to.

To address this I'm introducing `Context.private` which is the same as `Context.vars` but is _never_ updated with new variables after a block evaluation.