### PR TITLE
fix(output block): validate_config!/1

### DIFF
--- a/lib/flow_runner/spec/blocks/output.ex
+++ b/lib/flow_runner/spec/blocks/output.ex
@@ -11,8 +11,8 @@ defmodule FlowRunner.Spec.Blocks.Output do
   require Logger
 
   @impl true
-  def validate_config!(_config) do
-    %{}
+  def validate_config!(%{"value" => value}) do
+    %{value: value}
   end
 
   @impl true


### PR DESCRIPTION
fix `validate_config!/1` function from **Output** block to allow the `value` attribute following the [Output block spec](https://floip.gitbook.io/flow-specification/layers/blocks#output-block).