### PR TITLE
Evaluate case statement literals as blocks

### DIFF
--- a/lib/flow_runner/spec/blocks/case.ex
+++ b/lib/flow_runner/spec/blocks/case.ex
@@ -29,7 +29,12 @@ defmodule FlowRunner.Spec.Blocks.Case do
   def evaluate_outgoing(_flow, block, context, nil) do
     {:ok, block_exit} = Block.evaluate_exits(block, context)
 
-    {:ok, [result]} = FlowRunner.evaluate_expression(block_exit.name, context.vars)
-    {:ok, result}
+    case FlowRunner.evaluate_expression_block(block_exit.name, context.vars) do
+      {:ok, [result]} ->
+        {:ok, result}
+
+      {:error, _reason} ->
+        {:ok, block_exit.name}
+    end
   end
 end


### PR DESCRIPTION
We're using a hack where we're mis-using the Core.Case block to inject variables into the context.
That's a bad idea, we need a dedicated custom block type for that. In the mean time, this makes the behaviour a little more consistent. For the instances where we're using this, we're assuming that the expression is an expression block, which doesn't need the `@(...)` prefix