### PR TITLE
Allow library users to handle Core.RunFlow blocks instead of handling them internally

### DIFF
--- a/lib/context.ex
+++ b/lib/context.ex
@@ -9,6 +9,7 @@ defmodule FlowRunner.Context do
           mode: String.t(),
           log: [String.t()],
           waiting_for_user_input: boolean,
+          waiting_for_flow: nil | String.t(),
           current_flow_uuid: nil | String.t(),
           last_block_uuid: nil | String.t(),
           vars: map,
@@ -27,6 +28,8 @@ defmodule FlowRunner.Context do
     log: [],
     # Whether we are blocked pending user input
     waiting_for_user_input: false,
+    # In case we are waiting for a child flow to finish executing, this contains its UUID
+    waiting_for_flow: nil,
     # Flow uuid that is currently being run.
     current_flow_uuid: nil,
     # Uuid of the last block executed and rendered to the user. No exits have been evaluated.

--- a/lib/context.ex
+++ b/lib/context.ex
@@ -14,6 +14,8 @@ defmodule FlowRunner.Context do
           last_block_uuid: nil | String.t(),
           vars: map,
           finished: boolean,
+          parent_flow_uuid: nil | String.t(),
+          parent_state_uuid: nil | String.t(),
           parent_context: nil | t
         }
 
@@ -39,8 +41,9 @@ defmodule FlowRunner.Context do
     # private context
     private: %{},
     finished: false,
-    # If parent_context is not nil then we should return to parent context
-    # after we finish. (Part of Core.RunFlow)
+    # Details of the parent flow in case this flow was executed by a parent flow with `run_stack()`
+    parent_flow_uuid: nil,
+    parent_state_uuid: nil,
     parent_context: nil
   ]
 

--- a/lib/context.ex
+++ b/lib/context.ex
@@ -9,11 +9,12 @@ defmodule FlowRunner.Context do
           mode: String.t(),
           log: [String.t()],
           waiting_for_user_input: boolean,
-          waiting_for_flow: nil | String.t(),
           current_flow_uuid: nil | String.t(),
           last_block_uuid: nil | String.t(),
           vars: map,
           finished: boolean,
+          waiting_for_child_flow: boolean,
+          child_flow_uuid: nil | String.t(),
           parent_flow_uuid: nil | String.t(),
           parent_state_uuid: nil | String.t()
         }
@@ -29,8 +30,6 @@ defmodule FlowRunner.Context do
     log: [],
     # Whether we are blocked pending user input
     waiting_for_user_input: false,
-    # In case we are waiting for a child flow to finish executing, this contains its UUID
-    waiting_for_flow: nil,
     # Flow uuid that is currently being run.
     current_flow_uuid: nil,
     # Uuid of the last block executed and rendered to the user. No exits have been evaluated.
@@ -40,7 +39,10 @@ defmodule FlowRunner.Context do
     # private context
     private: %{},
     finished: false,
-    # Details of the parent flow in case this flow was executed by a parent flow with `run_stack()`
+    # Details of the child flow, in case this flow executed a child flow with `run_stack()`
+    waiting_for_child_flow: false,
+    child_flow_uuid: nil,
+    # Details of the parent flow, in case this flow was executed by a parent flow with `run_stack()`
     parent_flow_uuid: nil,
     parent_state_uuid: nil
   ]

--- a/lib/context.ex
+++ b/lib/context.ex
@@ -15,8 +15,7 @@ defmodule FlowRunner.Context do
           vars: map,
           finished: boolean,
           parent_flow_uuid: nil | String.t(),
-          parent_state_uuid: nil | String.t(),
-          parent_context: nil | t
+          parent_state_uuid: nil | String.t()
         }
 
   defstruct [
@@ -43,8 +42,7 @@ defmodule FlowRunner.Context do
     finished: false,
     # Details of the parent flow in case this flow was executed by a parent flow with `run_stack()`
     parent_flow_uuid: nil,
-    parent_state_uuid: nil,
-    parent_context: nil
+    parent_state_uuid: nil
   ]
 
   @doc """

--- a/lib/flow_runner.ex
+++ b/lib/flow_runner.ex
@@ -70,26 +70,7 @@ defmodule FlowRunner do
          {:ok, context, current_block, next_block} <-
            find_next_block(flow, context, user_input) do
       cond do
-        # If we have ended a Core.RunFlow block then continue where ever the parent left off
-        is_nil(next_block) && not is_nil(context.parent_context) ->
-          # swap parent & child contexts
-          {parent_context, child_context} = Map.pop(context, :parent_context)
-
-          {:ok, container, parent_flow} =
-            fetch_flow_by_uuid(container, parent_context.current_flow_uuid)
-
-          {:ok, parent_block} = Flow.fetch_block(parent_flow, parent_context.last_block_uuid)
-
-          parent_context_vars =
-            Map.put(parent_context.vars, parent_block.name, child_context.vars)
-
-          {:ok, context, _current_block, next_block} =
-            find_next_block(parent_flow, %{parent_context | vars: parent_context_vars}, nil)
-
-          evaluate_next_block(container, parent_flow, next_block, context)
-
-        # If we have a next block, automatically evaluate it as we're not waiting for user input
-        # which is guarded against explicitly above
+        # If we have a next block, automatically evaluate it
         not is_nil(next_block) ->
           evaluate_next_block(container, flow, next_block, context)
 

--- a/lib/flow_runner/spec/blocks/run_flow.ex
+++ b/lib/flow_runner/spec/blocks/run_flow.ex
@@ -9,7 +9,6 @@ defmodule FlowRunner.Spec.Blocks.RunFlow do
     the exit_block_id on the flow.
   """
   @behaviour FlowRunner.Spec.Block
-  alias FlowRunner.Context
   alias FlowRunner.Spec.Block
   alias FlowRunner.Spec.Container
   alias FlowRunner.Spec.Flow
@@ -36,21 +35,11 @@ defmodule FlowRunner.Spec.Blocks.RunFlow do
   def evaluate_incoming(
         %Container{} = container,
         %Flow{} = flow,
-        %Block{config: config} = block,
+        %Block{} = block,
         context
       ) do
-    next_flow_id = config.flow_id
-
-    context = %Context{context | last_block_uuid: block.uuid}
-
-    next_context = %Context{
-      Context.clone_empty(context)
-      | parent_context: context,
-        current_flow_uuid: next_flow_id,
-        last_block_uuid: nil
-    }
-
-    {:ok, container, flow, block, next_context}
+    {:ok, container, flow, block,
+     %{context | waiting_for_user_input: false, last_block_uuid: block.uuid}}
   end
 
   @impl true

--- a/test/flow_runner_test.exs
+++ b/test/flow_runner_test.exs
@@ -240,25 +240,6 @@ defmodule FlowRunnerTest do
     assert context.vars["block"]["value"] == "something unexpected"
   end
 
-  @tag flow: "test/runflow.flow"
-  test "runflow block", %{container: container} do
-    {:ok, context} =
-      FlowRunner.create_context(container, "f81559f9-1cf5-4125-abb0-4c88a1c4083f", "eng", "TEXT")
-
-    {:ok, container, flow, block, context} = FlowRunner.next_block(container, context)
-    assert resource_value(container, flow, context, block.config.prompt) == "flow 1"
-    # assert %{prompt: %{value: "flow 1"}} = output
-
-    {:ok, container, _flow, _block, context} = FlowRunner.next_block(container, context)
-    {:ok, container, flow, block, context} = FlowRunner.next_block(container, context)
-
-    assert resource_value(container, flow, context, block.config.prompt) == "flow 2"
-
-    {:ok, container, flow, block, context} = FlowRunner.next_block(container, context)
-    assert resource_value(container, flow, context, block.config.prompt) == "back to flow 1"
-    {:end, _container, _flow, _block, _context} = FlowRunner.next_block(container, context)
-  end
-
   @tag flow: "test/log.flow"
   test "log block", %{container: container} do
     {:ok, context} =


### PR DESCRIPTION
This PR removes the internal handling of `Core.RunFlow` blocks from the library and allows the library user to handle those blocks explicitly.

Only the library user knows what flows exist in their systems, so it makes more sense for them to handle `Core.RunFlow` blocks instead of handling those in this library.

For more details, see PR description in https://github.com/turnhub/engage/pull/3768