### PR TITLE
fallback to default language when language for context language code does not exist

### DIFF
--- a/lib/flow_runner.ex
+++ b/lib/flow_runner.ex
@@ -124,6 +124,35 @@ defmodule FlowRunner do
     do: FlowRunner.Spec.Resource.matching_resource(resource, language, mode, flow)
 
   @doc """
+  Get the language struct for a context
+
+  The FlowRunner.Context stores the language as an iso-639-3 language code ("eng"/"afr" etc).
+  Internally flowspec maintains a list of languages which have a UUID as an id.
+
+  Here we lookup the language struct for the language code currently active in the context.
+  This is needed because the Flowspec resource values refer to languages by the Language's ID (uuid)
+  rather than the iso-639-3 code.
+  """
+  @spec language_for_context(FlowRunner.Spec.Flow.t(), FlowRunner.Context.t()) ::
+          FlowRunner.Spec.Language.t()
+  def language_for_context(flow, context),
+    do:
+      Enum.find(flow.languages, &(&1.iso_639_3 == context.language)) ||
+        default_flow_language(flow)
+
+  @doc """
+  Get the default language for a flow.
+
+  The flowspec is unclear about how to go about this. Our assumption is
+  that the first language defined in the list of a flow's languages is
+  the default language.
+
+  The flowspec does guarantee that there must be at least 1 language.
+  """
+  @spec default_flow_language(FlowRunner.Spec.Flow.t()) :: FlowRunner.Spec.Language.t()
+  def default_flow_language(flow), do: List.first(flow.languages)
+
+  @doc """
   Find the next block the current context is expecting. Returns both the current block and the next
   block
   """

--- a/lib/flow_runner/spec/blocks/select_one_response.ex
+++ b/lib/flow_runner/spec/blocks/select_one_response.ex
@@ -126,8 +126,10 @@ defmodule FlowRunner.Spec.Blocks.SelectOneResponse do
     if matched_option do
       {:ok, resource} = FlowRunner.fetch_resource_by_uuid(container, matched_option.prompt)
 
+      language = FlowRunner.language_for_context(flow, context)
+
       {:ok, resource_value} =
-        FlowRunner.fetch_resource_value(resource, context.language, context.mode, flow)
+        FlowRunner.fetch_resource_value(resource, language.iso_639_3, context.mode, flow)
 
       {:ok,
        %{

--- a/test/flow_runner_test.exs
+++ b/test/flow_runner_test.exs
@@ -271,7 +271,6 @@ defmodule FlowRunnerTest do
     assert context.vars["block"]["value"] == "something unexpected"
   end
 
-  @tag :current
   @tag flow: "test/change-language.flow"
   test "changing language with a known language", %{container: container} do
     [flow] = container.flows
@@ -310,7 +309,6 @@ defmodule FlowRunnerTest do
              "done"
   end
 
-  @tag :current
   @tag flow: "test/change-language.flow"
   test "changing language with an unknown language", %{container: container} do
     [flow] = container.flows

--- a/test/flow_runner_test.exs
+++ b/test/flow_runner_test.exs
@@ -5,6 +5,37 @@ defmodule FlowRunnerTest do
 
   setup :with_flow_loader!
 
+  describe "language resolving" do
+    setup do
+      eng = %FlowRunner.Spec.Language{iso_639_3: "eng"}
+      afr = %FlowRunner.Spec.Language{iso_639_3: "afr"}
+
+      {:ok, languages: [eng, afr]}
+    end
+
+    test "default_flow_language", %{languages: [eng, afr]} do
+      flow = %FlowRunner.Spec.Flow{languages: [eng, afr]}
+      assert FlowRunner.default_flow_language(flow) == eng
+    end
+
+    test "language_for_context for known languages", %{languages: [eng, afr]} do
+      flow = %FlowRunner.Spec.Flow{languages: [eng, afr]}
+
+      assert FlowRunner.language_for_context(flow, %FlowRunner.Context{language: eng.iso_639_3}) ==
+               eng
+
+      assert FlowRunner.language_for_context(flow, %FlowRunner.Context{language: afr.iso_639_3}) ==
+               afr
+    end
+
+    test "language_for_context for unknown languages", %{languages: [eng, afr]} do
+      flow = %FlowRunner.Spec.Flow{languages: [eng, afr]}
+      # fallback to english (default)
+      assert FlowRunner.language_for_context(flow, %FlowRunner.Context{language: "nld"}) ==
+               eng
+    end
+  end
+
   @tag flow: "test/basic.flow"
   test "compile a flow", %{container: container} do
     assert container
@@ -238,6 +269,58 @@ defmodule FlowRunnerTest do
 
     assert context.vars["choose"] == "something unexpected"
     assert context.vars["block"]["value"] == "something unexpected"
+  end
+
+  @tag :current
+  @tag flow: "test/change-language.flow"
+  test "changing language", %{container: container} do
+    {:ok, context} =
+      FlowRunner.create_context(
+        container,
+        "efaabaac-d035-43f5-a7fe-0e4e757c8095",
+        "fra",
+        "TEXT",
+        %{
+          "contact" => %{"name" => "foo bar"}
+        }
+      )
+
+    {:ok, container, flow, block, context} = FlowRunner.next_block(container, context)
+    assert resource_value(container, flow, context, block.config.prompt) == "اختر اسمًا"
+    assert context.waiting_for_user_input
+
+    {:ok, container, flow, block, context} = FlowRunner.next_block(container, context, "maalika")
+    assert %{prompt: resource_uuid} = block.config
+    assert resource_value(container, flow, context, resource_uuid) == "salaam maalika"
+    refute context.waiting_for_user_input
+
+    {:end, _container, _flow, _block, _context} = FlowRunner.next_block(container, context)
+
+    {:ok, context} =
+      FlowRunner.create_context(
+        container,
+        "efaabaac-d035-43f5-a7fe-0e4e757c8095",
+        "eng",
+        "TEXT",
+        %{
+          "contact" => %{"name" => "foo bar"}
+        }
+      )
+
+    {:ok, container, flow, block, context} = FlowRunner.next_block(container, context)
+    assert %{prompt: resource_uuid} = block.config
+
+    assert resource_value(container, flow, context, resource_uuid) ==
+             "hi *@PROPER(contact.name)*! Choose a name:"
+
+    assert context.waiting_for_user_input
+    {:ok, container, flow, block, context} = FlowRunner.next_block(container, context, "yaseen")
+
+    assert %{prompt: resource_uuid} = block.config
+    assert resource_value(container, flow, context, resource_uuid) == "hello yaseen"
+
+    refute context.waiting_for_user_input
+    {:end, _container, _flow, _block, _context} = FlowRunner.next_block(container, context)
   end
 
   @tag flow: "test/log.flow"

--- a/test/support/flow_runner/test/utils.ex
+++ b/test/support/flow_runner/test/utils.ex
@@ -45,9 +45,10 @@ defmodule FlowRunner.Test.Utils do
 
   def resource_value(container, flow, context, resource_uuid) do
     {:ok, resource} = FlowRunner.fetch_resource_by_uuid(container, resource_uuid)
+    language = FlowRunner.language_for_context(flow, context)
 
     {:ok, resource_value} =
-      FlowRunner.fetch_resource_value(resource, context.language, context.mode, flow)
+      FlowRunner.fetch_resource_value(resource, language.iso_639_3, context.mode, flow)
 
     resource_value.value
   end


### PR DESCRIPTION
There are use cases where a contact's language can be updated to a language of preference and that is then applied to the context. However, this doesn't mean that the language exists in the Flow specification. When that is the case, default to the first (default) language instead of crashing.