### PR TITLE
use warning instead of error, this is a FLOIP level problem to be fixed

### DIFF
--- a/lib/flow_runner/spec/blocks/log.ex
+++ b/lib/flow_runner/spec/blocks/log.ex
@@ -42,7 +42,15 @@ defmodule FlowRunner.Spec.Blocks.Log do
               %Context{context | log: [log.value | context.log], last_block_uuid: block.uuid}
 
             {:error, reason} ->
-              Logger.error("Unable to resolve resource for log, reason: #{inspect(reason)}.")
+              Logger.warning("Unable to resolve resource for log, reason: #{inspect(reason)}.",
+                metadata: [
+                  language: context.language,
+                  resource: resource.uuid,
+                  flow: flow.uuid,
+                  container: container.uuid
+                ]
+              )
+
               %Context{context | last_block_uuid: block.uuid}
           end
 

--- a/lib/flow_runner/spec/blocks/log.ex
+++ b/lib/flow_runner/spec/blocks/log.ex
@@ -42,6 +42,7 @@ defmodule FlowRunner.Spec.Blocks.Log do
               %Context{context | log: [log.value | context.log], last_block_uuid: block.uuid}
 
             {:error, reason} ->
+              # credo:disable-for-next-line
               Logger.warning("Unable to resolve resource for log, reason: #{inspect(reason)}.",
                 metadata: [
                   language: context.language,


### PR DESCRIPTION
When someone attempts to run a FLOIP spec with an incomplete language resource set the current implementation will spew a lot of errors, however there's little we can do about that, the real fix is making sure the FLOIP spec is correct.

Switching this to a warning to reduce the noise.