### PR TITLE
remove list_resources_referenced

### DIFF
--- a/lib/flow_runner/spec/block.ex
+++ b/lib/flow_runner/spec/block.ex
@@ -15,7 +15,6 @@ defmodule FlowRunner.Spec.Block do
   alias FlowRunner.Spec.Container
   alias FlowRunner.Spec.Exit
   alias FlowRunner.Spec.Flow
-  alias FlowRunner.Spec.Resource
 
   require Logger
 
@@ -47,20 +46,6 @@ defmodule FlowRunner.Spec.Block do
               {:ok, user_input :: any}
               | {:invalid, reason :: String.t()}
 
-  @doc """
-  Return a list of all resources referenced by a block
-
-  This is needed so we can merge flows between containers. Flows depend on resources
-  but RC3 of the flowspec states that these resources are keep at the container level
-  rather than the flow level.
-
-  This callback gives us the resources a flow depends on from the container.
-
-  RC4 may move the resources into the flows themselves which would remove the need
-  for this function entirely.
-  """
-  @callback list_resources_referenced(Container.t(), Block.t()) :: [Resource.t()]
-
   @derive Jason.Encoder
   defstruct uuid: nil,
             name: nil,
@@ -90,12 +75,6 @@ defmodule FlowRunner.Spec.Block do
   validates(:type, presence: true)
 
   def get_block(blocks_module, type), do: Map.get(blocks_module.blocks, type)
-
-  @spec list_resources_referenced(Container.t(), Block.t()) :: [Resource.t()]
-  def list_resources_referenced(container, block) do
-    implementation = get_block(FlowRunner.blocks_module(), block.type)
-    apply(implementation, :list_resources_referenced, [container, block])
-  end
 
   @impl true
   def cast!(blocks_module, %{"type" => type} = map) do

--- a/lib/flow_runner/spec/blocks/case.ex
+++ b/lib/flow_runner/spec/blocks/case.ex
@@ -17,9 +17,6 @@ defmodule FlowRunner.Spec.Blocks.Case do
   end
 
   @impl true
-  def list_resources_referenced(_container, _block), do: []
-
-  @impl true
   @decorate trace("FlowRunner.Case.Log.evaluate_incoming")
   def evaluate_incoming(
         %Container{} = container,

--- a/lib/flow_runner/spec/blocks/log.ex
+++ b/lib/flow_runner/spec/blocks/log.ex
@@ -22,9 +22,6 @@ defmodule FlowRunner.Spec.Blocks.Log do
   end
 
   @impl true
-  def list_resources_referenced(_container, _block), do: []
-
-  @impl true
   @decorate trace("FlowRunner.Blocks.Log.evaluate_incoming")
   def evaluate_incoming(
         %Container{} = container,

--- a/lib/flow_runner/spec/blocks/message.ex
+++ b/lib/flow_runner/spec/blocks/message.ex
@@ -24,10 +24,6 @@ defmodule FlowRunner.Spec.Blocks.Message do
   end
 
   @impl true
-  def list_resources_referenced(container, %{config: %{prompt: resource_uuid}}),
-    do: Enum.filter(container.resources, &(&1.uuid == resource_uuid))
-
-  @impl true
   @decorate trace("FlowRunner.Blocks.Message.evaluate_incoming")
   def evaluate_incoming(container, %Flow{} = flow, %Block{} = block, context) do
     {

--- a/lib/flow_runner/spec/blocks/numeric_response.ex
+++ b/lib/flow_runner/spec/blocks/numeric_response.ex
@@ -34,10 +34,6 @@ defmodule FlowRunner.Spec.Blocks.NumericResponse do
   end
 
   @impl true
-  def list_resources_referenced(container, %{config: %{prompt: resource_uuid}}),
-    do: Enum.filter(container.resources, &(&1.uuid == resource_uuid))
-
-  @impl true
   @decorate trace("FlowRunner.Blocks.NumericResponse.evaluate_incoming")
   def evaluate_incoming(container, flow, block, context) do
     {

--- a/lib/flow_runner/spec/blocks/open_response.ex
+++ b/lib/flow_runner/spec/blocks/open_response.ex
@@ -32,10 +32,6 @@ defmodule FlowRunner.Spec.Blocks.OpenResponse do
   end
 
   @impl true
-  def list_resources_referenced(container, %{config: %{prompt: resource_uuid}}),
-    do: Enum.filter(container.resources, &(&1.uuid == resource_uuid))
-
-  @impl true
   @decorate trace("FlowRunner.Blocks.OpenResponse.evaluate_incoming")
   def evaluate_incoming(container, flow, block, context) do
     {

--- a/lib/flow_runner/spec/blocks/output.ex
+++ b/lib/flow_runner/spec/blocks/output.ex
@@ -17,9 +17,6 @@ defmodule FlowRunner.Spec.Blocks.Output do
   end
 
   @impl true
-  def list_resources_referenced(_container, _block), do: []
-
-  @impl true
   @decorate trace("FlowRunner.Blocks.Output.evaluate_incoming")
   def evaluate_incoming(
         %Container{} = container,

--- a/lib/flow_runner/spec/blocks/run_flow.ex
+++ b/lib/flow_runner/spec/blocks/run_flow.ex
@@ -15,9 +15,6 @@ defmodule FlowRunner.Spec.Blocks.RunFlow do
   alias FlowRunner.Spec.Flow
 
   @impl true
-  def list_resources_referenced(_container, _block), do: []
-
-  @impl true
   def validate_config!(%{"flow_id" => flow_id}) do
     config = %{flow_id: flow_id}
 

--- a/lib/flow_runner/spec/blocks/select_one_response.ex
+++ b/lib/flow_runner/spec/blocks/select_one_response.ex
@@ -47,15 +47,6 @@ defmodule FlowRunner.Spec.Blocks.SelectOneResponse do
     raise "invalid config, 'prompt' and 'choices' fields required"
   end
 
-  @impl true
-  def list_resources_referenced(
-        container,
-        %{config: %{prompt: resource_uuid, choices: choices}}
-      ) do
-    resource_uuids = [resource_uuid | Enum.map(choices, & &1.prompt)]
-    Enum.filter(container.resources, &Enum.member?(resource_uuids, &1))
-  end
-
   defp validate_choices(choices) do
     {valid_choices, invalid_choices} =
       choices

--- a/lib/flow_runner/spec/blocks/set_contact_property.ex
+++ b/lib/flow_runner/spec/blocks/set_contact_property.ex
@@ -17,9 +17,6 @@ defmodule FlowRunner.Spec.Blocks.SetContactProperty do
   end
 
   @impl true
-  def list_resources_referenced(_container, _block), do: []
-
-  @impl true
   @decorate trace("FlowRunner.Blocks.SetContactProperty.evaluate_incoming")
   def evaluate_incoming(
         %Container{} = container,

--- a/lib/flow_runner/spec/blocks/set_group_membership.ex
+++ b/lib/flow_runner/spec/blocks/set_group_membership.ex
@@ -27,9 +27,6 @@ defmodule FlowRunner.Spec.Blocks.SetGroupMembership do
   end
 
   @impl true
-  def list_resources_referenced(_container, _block), do: []
-
-  @impl true
   @decorate trace("FlowRunner.Blocks.SetGroupMembership.evaluate_incoming")
   def evaluate_incoming(
         %Container{} = container,

--- a/lib/flow_runner/spec/container.ex
+++ b/lib/flow_runner/spec/container.ex
@@ -9,7 +9,6 @@ defmodule FlowRunner.Spec.Container do
     ]
 
   alias FlowRunner.Spec.Container
-  alias FlowRunner.Spec.Flow
 
   @derive Jason.Encoder
   defstruct specification_version: nil,
@@ -36,21 +35,6 @@ defmodule FlowRunner.Spec.Container do
   )
 
   validates(:uuid, presence: true, uuid: [format: :default])
-
-  def insert_flow_and_resources(
-        %Container{} = destination_container,
-        %Container{} = source_container,
-        %Flow{} = flow
-      ) do
-    %{
-      destination_container
-      | flows: destination_container.flows ++ [flow],
-        # NOTE: there should be a better way to do this
-        resources:
-          destination_container.resources ++
-            Flow.list_resources_referenced(source_container, flow)
-    }
-  end
 
   @spec fetch_resource_by_uuid(Container.t(), uuid :: String.t()) ::
           {:ok, FlowRunner.Spec.Resource.t()} | {:error, reason :: String.t()}

--- a/lib/flow_runner/spec/flow.ex
+++ b/lib/flow_runner/spec/flow.ex
@@ -37,12 +37,6 @@ defmodule FlowRunner.Spec.Flow do
 
   validates(:uuid, presence: true, uuid: [format: :default])
 
-  def list_resources_referenced(container, flow) do
-    Enum.reduce(flow.blocks, [], fn block, acc ->
-      FlowRunner.Spec.Block.list_resources_referenced(container, block) ++ acc
-    end)
-  end
-
   def cast!(params) do
     cast_datetime!(params, "last_modified")
   end


### PR DESCRIPTION
This removes the `list_resources_referenced` callback, it wasn't (isn't) being used anywhere and the problem it was meant to solve is better solved higher up in the applications calling this library rather than in the flow runner itself.