### PR TITLE
fix: make `variant` and `bcp_47` of language optional and clean dialyzer ignores

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ by adding `flow_runner` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:flow_runner, "~> 5.18.0"}
+    {:flow_runner, "~> 5.18.1"}
   ]
 end
 ```

--- a/config/dialyzer.ignore.exs
+++ b/config/dialyzer.ignore.exs
@@ -1,3 +1,1 @@
-[
-  {"lib/mix/tasks/release_candidate.ex"}
-]
+[]

--- a/lib/context.ex
+++ b/lib/context.ex
@@ -20,7 +20,7 @@ defmodule FlowRunner.Context do
         }
 
   defstruct [
-    # iso 639-3 language code.
+    # bcp 47 or iso 639-3 language code.
     language: "eng",
     mode: "TEXT",
 

--- a/lib/flow_runner/spec/language.ex
+++ b/lib/flow_runner/spec/language.ex
@@ -12,8 +12,8 @@ defmodule FlowRunner.Spec.Language do
           id: String.t(),
           iso_639_3: String.t(),
           label: String.t(),
-          variant: String.t(),
-          bcp_47: String.t()
+          variant: String.t() | nil,
+          bcp_47: String.t() | nil
         }
 
   validates(:id, presence: true)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule FlowRunner.MixProject do
   use Mix.Project
 
-  @version "5.18.0"
+  @version "5.18.1"
 
   def project do
     [


### PR DESCRIPTION
`variant` and `bcp_47` are optional fields

ref PROD-973