### PR TITLE
fix(release-workflow): add Git installation step for release and bump version

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -20,6 +20,8 @@ jobs:
           mix local.hex --force
           mix deps.get
           mix compile
+      - name: Install Git
+        run: sudo apt-get update && sudo apt-get install -y git
       - name: Publish package to hex.pm
         uses: wesleimp/action-publish-hex@v1
         env:

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule FlowRunner.MixProject do
   use Mix.Project
 
-  @version "5.18.1"
+  @version "5.18.2"
 
   def project do
     [


### PR DESCRIPTION
It's [failing publishing hex package](https://github.com/turnhub/flow_runner/actions/runs/13316810949/job/37192727423).
This PR adds `git`, it's a dependency to publish to hex.
