### PR TITLE
fix(workflow): correct package publishing in releases workflow

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -16,13 +16,13 @@ jobs:
           otp-version: "27"
       - name: Install Dependencies
         run: |
-          mix local.rebar --force
           mix local.hex --force
+          mix local.rebar --force
           mix deps.get
           mix compile
-      - name: Install Git
-        run: sudo apt-get update && sudo apt-get install -y git
       - name: Publish package to hex.pm
-        uses: wesleimp/action-publish-hex@v1
+        run: |
+          mix hex.build
+          mix hex.publish --yes
         env:
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule FlowRunner.MixProject do
   use Mix.Project
 
-  @version "5.18.2"
+  @version "5.18.3"
 
   def project do
     [


### PR DESCRIPTION
The `releases.yml` GitHub Actions workflow has been updated to address an issue in the package publishing process. 

The issue is related to missing "git" when publishing using the action, the action is using an old Dockerfile image.

[Previous PR](https://github.com/turnhub/flow_runner/pull/240) trying to fix
