### PR TITLE
fix(flow_runner): language fallback logic

### DIFF
--- a/lib/flow_runner.ex
+++ b/lib/flow_runner.ex
@@ -121,8 +121,7 @@ defmodule FlowRunner do
           FlowRunner.Spec.Language.t()
   def language_for_context(flow, context),
     do:
-      Enum.find(flow.languages, &(&1.iso_639_3 == context.language)) ||
-        default_flow_language(flow)
+      Enum.find(flow.languages, default_flow_language(flow), &(&1.iso_639_3 == context.language))
 
   @doc """
   Get the default language for a flow.

--- a/lib/flow_runner/custom_blocks/webhook.ex
+++ b/lib/flow_runner/custom_blocks/webhook.ex
@@ -89,7 +89,7 @@ defmodule FlowRunner.CustomBlocks.Webhook do
       # We also include a floor of a 10the of a second so that we handle unreasonably
       # low wait times as well.
       timeout: max(min(timeout, @maximum_timeout), 100),
-      cache_ttl: Map.get(webhook, "cache_ttl") || @default_cache_ttl,
+      cache_ttl: Map.get(webhook, "cache_ttl", @default_cache_ttl),
       mode: mode
     }
     |> Map.from_struct()
@@ -117,7 +117,7 @@ defmodule FlowRunner.CustomBlocks.Webhook do
   defp group_by_key(enumerable) do
     Enum.reduce(enumerable, %{}, fn {key, value}, acc ->
       string_key = to_string(key)
-      value_list = Map.get(acc, string_key) || []
+      value_list = Map.get(acc, string_key, [])
       Map.put(acc, string_key, [value | value_list])
     end)
   end

--- a/lib/flow_runner/simulator.ex
+++ b/lib/flow_runner/simulator.ex
@@ -44,10 +44,13 @@ defmodule FlowRunner.Simulator do
 
   def update_context(sim, vars \\ %{}, language_code \\ "eng", mode \\ "RICH_MESSAGING") do
     [first_flow | _] = sim.container.flows
-    [first_language | _] = first_flow.languages
 
     # get the language for the language_code, fallback to the first_language if none match
-    language = Enum.find(first_flow.languages, first_language, &(&1.iso_639_3 == language_code))
+    language =
+      FlowRunner.language_for_context(
+        first_flow,
+        sim.context || %FlowRunner.Context{language: language_code}
+      )
 
     {:ok, context} =
       if sim.context,

--- a/lib/flow_runner/spec/resource.ex
+++ b/lib/flow_runner/spec/resource.ex
@@ -33,8 +33,8 @@ defmodule FlowRunner.Spec.Resource do
       )
 
     # Filter resources by language and mode.
-    matching_source? = fn x ->
-      x.language_id == language.id && ResourceValue.supports_mode(x, mode)
+    matching_source? = fn resource ->
+      resource.language_id == language.id && ResourceValue.supports_mode(resource, mode)
     end
 
     resource_values = Enum.filter(resources, matching_source?)

--- a/lib/flow_runner/spec/resource.ex
+++ b/lib/flow_runner/spec/resource.ex
@@ -24,27 +24,26 @@ defmodule FlowRunner.Spec.Resource do
 
   @spec matching_resource(Resource.t(), language :: String.t(), mode :: String.t(), Flow.t()) ::
           {:ok, ResourceValue.t()} | {:error, String.t()}
-  def matching_resource(%Resource{values: resources}, language, mode, %Flow{languages: languages}) do
+  def matching_resource(%Resource{values: resources}, language, mode, flow) do
     # Identify the language object that corresponds to our iso-639-3 code.
-    languages = Enum.filter(languages, &(&1.iso_639_3 == language))
+    language =
+      FlowRunner.language_for_context(
+        flow,
+        %FlowRunner.Context{language: language}
+      )
 
-    if length(languages) > 0 do
-      [language | _] = languages
-      # Filter resources by language and mode.
-      matching_source? = fn x ->
-        x.language_id == language.id && ResourceValue.supports_mode(x, mode)
-      end
+    # Filter resources by language and mode.
+    matching_source? = fn x ->
+      x.language_id == language.id && ResourceValue.supports_mode(x, mode)
+    end
 
-      resource_values = Enum.filter(resources, matching_source?)
+    resource_values = Enum.filter(resources, matching_source?)
 
-      if length(resource_values) > 0 do
-        [resource_value | _] = resource_values
-        {:ok, resource_value}
-      else
-        {:error, "no matching resource"}
-      end
+    if length(resource_values) > 0 do
+      [resource_value | _] = resource_values
+      {:ok, resource_value}
     else
-      {:error, "no matching languages for resource"}
+      {:error, "no matching resource"}
     end
   end
 end

--- a/lib/flow_runner/spec/resource.ex
+++ b/lib/flow_runner/spec/resource.ex
@@ -32,15 +32,14 @@ defmodule FlowRunner.Spec.Resource do
         %FlowRunner.Context{language: language}
       )
 
-    # Filter resources by language and mode.
+    # Find resource by language and mode.
     matching_source? = fn resource ->
       resource.language_id == language.id && ResourceValue.supports_mode(resource, mode)
     end
 
-    resource_values = Enum.filter(resources, matching_source?)
+    resource_value = Enum.find(resources, matching_source?)
 
-    if length(resource_values) > 0 do
-      [resource_value | _] = resource_values
+    if resource_value do
       {:ok, resource_value}
     else
       {:error, "no matching resource"}

--- a/test/resource_test.exs
+++ b/test/resource_test.exs
@@ -24,18 +24,29 @@ defmodule ResourceTest do
           language_id: "25",
           modes: ["USSD", "TEXT"],
           value: "non-existent language"
+        },
+        %ResourceValue{
+          language_id: "22",
+          modes: ["USSD"],
+          value: "english"
         }
       ]
     }
 
     # no matching language
-    assert {:error, _} = Resource.matching_resource(resource, "eng", "TEXT", @flow)
+    assert Resource.matching_resource(resource, "eng", "TEXT", @flow) ==
+             {:error, "no matching resource"}
 
     # no matching mode.
-    assert {:error, _} = Resource.matching_resource(resource, "fra", "RICH_MESSAGING", @flow)
+    assert Resource.matching_resource(resource, "fra", "RICH_MESSAGING", @flow) ==
+             {:error, "no matching resource"}
 
     # matching language and mode
     assert {:ok, %ResourceValue{value: "french"}} =
              Resource.matching_resource(resource, "fra", "TEXT", @flow)
+
+    # no matching languages for resource should use default language
+    assert {:ok, %ResourceValue{value: "english"}} =
+             Resource.matching_resource(resource, "por", "USSD", @flow)
   end
 end


### PR DESCRIPTION
### Issue Description

The current implementation of the `FlowRunner.Spec.Resource` module has a limitation in handling language fallback language (when the `context.language` language is not in the list of `flow` languages), it's returning an error `{:error, "no matching languages for resource"}`.

### Solution

The proposed changes address this issue by using default language when `context.language` not in `flow` languages.