### PR TITLE
feat: support translated WhatsApp template body params

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: "1.17"
+          elixir-version: "1.18"
           otp-version: "27"
       - name: Install Dependencies
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.17.1-otp-27
+elixir 1.18.3-otp-27
 erlang 27.0

--- a/lib/flow_runner/custom_blocks/whatsapp_template_message.ex
+++ b/lib/flow_runner/custom_blocks/whatsapp_template_message.ex
@@ -54,17 +54,17 @@ defmodule FlowRunner.CustomBlocks.WhatsAppTemplateMessage do
          parameters: Enum.map(parameters, &parse_parameter(&1, template_language))
        }
 
-  def parse_parameter(%{"type" => "text", "text" => text} = component, template_language),
+  defp parse_parameter(%{"type" => "text", "text" => text} = component, template_language),
     do: %{
       type: "text",
       text: text,
       language: component["language"] || Expression.evaluate_block!(template_language)
     }
 
-  def parse_parameter(
-        %{"type" => "document", "document" => %{"link" => link} = document},
-        _default_language
-      ) do
+  defp parse_parameter(
+         %{"type" => "document", "document" => %{"link" => link} = document},
+         _default_language
+       ) do
     document =
       if filename = document["filename"] do
         %{link: link, filename: filename}
@@ -75,17 +75,17 @@ defmodule FlowRunner.CustomBlocks.WhatsAppTemplateMessage do
     %{type: "document", document: document}
   end
 
-  def parse_parameter(%{"type" => "video", "video" => %{"link" => link}}, _default_language),
+  defp parse_parameter(%{"type" => "video", "video" => %{"link" => link}}, _default_language),
     do: %{type: "video", video: %{link: link}}
 
-  def parse_parameter(%{"type" => "image", "image" => %{"link" => link}}, _default_language),
+  defp parse_parameter(%{"type" => "image", "image" => %{"link" => link}}, _default_language),
     do: %{type: "image", image: %{link: link}}
 
-  def parse_parameter(
-        %{"type" => "payload", "payload" => payload_resource_uuid},
-        _default_language
-      ),
-      do: %{type: "payload", payload: payload_resource_uuid}
+  defp parse_parameter(
+         %{"type" => "payload", "payload" => payload_resource_uuid},
+         _default_language
+       ),
+       do: %{type: "payload", payload: payload_resource_uuid}
 
   @impl FlowRunner.Spec.Block
   @decorate with_span("DSL.Blocks.WhatsAppTemplateMessage.evaluate_incoming")

--- a/lib/flow_runner/custom_blocks/whatsapp_template_message.ex
+++ b/lib/flow_runner/custom_blocks/whatsapp_template_message.ex
@@ -37,7 +37,11 @@ defmodule FlowRunner.CustomBlocks.WhatsAppTemplateMessage do
       }
 
   def parse_parameter(%{"type" => "text", "text" => text} = component, template_language),
-    do: %{type: "text", text: text, language: component["language"] || template_language}
+    do: %{
+      type: "text",
+      text: text,
+      language: component["language"] || Expression.evaluate_block!(template_language)
+    }
 
   def parse_parameter(
         %{"type" => "document", "document" => %{"link" => link} = document},

--- a/lib/flow_runner/custom_blocks/whatsapp_template_message.ex
+++ b/lib/flow_runner/custom_blocks/whatsapp_template_message.ex
@@ -5,7 +5,7 @@ defmodule FlowRunner.CustomBlocks.WhatsAppTemplateMessage do
 
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
-  @impl true
+  @impl FlowRunner.Spec.Block
   def validate_config!(%{
         "template" =>
           %{
@@ -33,8 +33,8 @@ defmodule FlowRunner.CustomBlocks.WhatsAppTemplateMessage do
       parameters: Enum.map(parameters, &parse_parameter/1)
     }
 
-  def parse_parameter(%{"type" => "text", "text" => text}),
-    do: %{type: "text", text: text}
+  def parse_parameter(%{"type" => "text", "text" => text} = component),
+    do: %{type: "text", text: text, language: component["language"]}
 
   def parse_parameter(%{"type" => "document", "document" => %{"link" => link} = document}) do
     document =
@@ -56,7 +56,7 @@ defmodule FlowRunner.CustomBlocks.WhatsAppTemplateMessage do
   def parse_parameter(%{"type" => "payload", "payload" => payload_resource_uuid}),
     do: %{type: "payload", payload: payload_resource_uuid}
 
-  @impl true
+  @impl FlowRunner.Spec.Block
   @decorate with_span("DSL.Blocks.WhatsAppTemplateMessage.evaluate_incoming")
   def evaluate_incoming(container, flow, block, context) do
     context = %{
@@ -69,7 +69,7 @@ defmodule FlowRunner.CustomBlocks.WhatsAppTemplateMessage do
     {:ok, container, flow, block, context}
   end
 
-  @impl true
+  @impl FlowRunner.Spec.Block
   def evaluate_outgoing(_container, _flow, _block, _context, nil), do: {:ok, nil}
 
   @template_button_indices Enum.map(0..9, &to_string/1)

--- a/lib/flow_runner/custom_blocks/whatsapp_template_message.ex
+++ b/lib/flow_runner/custom_blocks/whatsapp_template_message.ex
@@ -24,17 +24,35 @@ defmodule FlowRunner.CustomBlocks.WhatsAppTemplateMessage do
     }
   end
 
-  def parse_component(
-        %{"type" => type, "parameters" => parameters} = component,
-        template_language
-      ),
-      do: %{
-        type: type,
-        index: component["index"],
-        # required only for buttons
-        sub_type: component["sub_type"],
-        parameters: Enum.map(parameters, &parse_parameter(&1, template_language))
-      }
+  @spec parse_component(
+          %{
+            required(String.t()) => String.t(),
+            required(String.t()) => list(%{String.t() => String.t()})
+          },
+          String.t()
+        ) :: %{
+          type: String.t(),
+          index: String.t() | nil,
+          sub_type: String.t() | nil,
+          parameters:
+            list(%{
+              required(:type) => String.t(),
+              optional(:text) => String.t(),
+              optional(:payload) => String.t(),
+              optional(:language) => String.t()
+            })
+        }
+  defp parse_component(
+         %{"type" => type, "parameters" => parameters} = component,
+         template_language
+       ),
+       do: %{
+         type: type,
+         index: component["index"],
+         # required only for buttons
+         sub_type: component["sub_type"],
+         parameters: Enum.map(parameters, &parse_parameter(&1, template_language))
+       }
 
   def parse_parameter(%{"type" => "text", "text" => text} = component, template_language),
     do: %{

--- a/lib/flow_runner/custom_blocks/whatsapp_template_message.ex
+++ b/lib/flow_runner/custom_blocks/whatsapp_template_message.ex
@@ -18,25 +18,31 @@ defmodule FlowRunner.CustomBlocks.WhatsAppTemplateMessage do
       template: %{
         name: name,
         language: %{code: code},
-        components: Enum.map(components, &parse_component/1),
+        components: Enum.map(components, &parse_component(&1, code)),
         tracking: Map.get(template, "tracking")
       }
     }
   end
 
-  def parse_component(%{"type" => type, "parameters" => parameters} = component),
-    do: %{
-      type: type,
-      index: component["index"],
-      # required only for buttons
-      sub_type: component["sub_type"],
-      parameters: Enum.map(parameters, &parse_parameter/1)
-    }
+  def parse_component(
+        %{"type" => type, "parameters" => parameters} = component,
+        template_language
+      ),
+      do: %{
+        type: type,
+        index: component["index"],
+        # required only for buttons
+        sub_type: component["sub_type"],
+        parameters: Enum.map(parameters, &parse_parameter(&1, template_language))
+      }
 
-  def parse_parameter(%{"type" => "text", "text" => text} = component),
-    do: %{type: "text", text: text, language: component["language"]}
+  def parse_parameter(%{"type" => "text", "text" => text} = component, template_language),
+    do: %{type: "text", text: text, language: component["language"] || template_language}
 
-  def parse_parameter(%{"type" => "document", "document" => %{"link" => link} = document}) do
+  def parse_parameter(
+        %{"type" => "document", "document" => %{"link" => link} = document},
+        _default_language
+      ) do
     document =
       if filename = document["filename"] do
         %{link: link, filename: filename}
@@ -47,14 +53,17 @@ defmodule FlowRunner.CustomBlocks.WhatsAppTemplateMessage do
     %{type: "document", document: document}
   end
 
-  def parse_parameter(%{"type" => "video", "video" => %{"link" => link}}),
+  def parse_parameter(%{"type" => "video", "video" => %{"link" => link}}, _default_language),
     do: %{type: "video", video: %{link: link}}
 
-  def parse_parameter(%{"type" => "image", "image" => %{"link" => link}}),
+  def parse_parameter(%{"type" => "image", "image" => %{"link" => link}}, _default_language),
     do: %{type: "image", image: %{link: link}}
 
-  def parse_parameter(%{"type" => "payload", "payload" => payload_resource_uuid}),
-    do: %{type: "payload", payload: payload_resource_uuid}
+  def parse_parameter(
+        %{"type" => "payload", "payload" => payload_resource_uuid},
+        _default_language
+      ),
+      do: %{type: "payload", payload: payload_resource_uuid}
 
   @impl FlowRunner.Spec.Block
   @decorate with_span("DSL.Blocks.WhatsAppTemplateMessage.evaluate_incoming")

--- a/lib/flow_runner/simulator.ex
+++ b/lib/flow_runner/simulator.ex
@@ -412,6 +412,9 @@ defmodule FlowRunner.Simulator do
       template_components
       |> Enum.find(%{}, &(&1.type == "body"))
       |> Map.get(:parameters, [])
+      |> Enum.filter(fn parameter ->
+        parameter[:language] == sim.language.iso_639_3
+      end)
       |> Enum.map_join(", ", fn %{text: param} ->
         param
         |> Expression.evaluate_block!(context_vars, sim.callbacks_module)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule FlowRunner.MixProject do
   use Mix.Project
 
-  @version "5.23.4"
+  @version "5.24.0"
 
   def project do
     [

--- a/priv/fixtures/test/simulator/whatsapp_template_message_with_translations.flow
+++ b/priv/fixtures/test/simulator/whatsapp_template_message_with_translations.flow
@@ -1,0 +1,140 @@
+{
+  "name": "My Journey",
+  "description": "Default description",
+  "uuid": "2359d81e-596a-4551-b6b7-5301c5d3a45b",
+  "resources": [],
+  "flows": [
+    {
+      "label": null,
+      "name": "stack",
+      "blocks": [
+        {
+          "label": null,
+          "name": "card_whatsapp_template_message",
+          "type": "Io.Turn.WhatsAppTemplateMessage",
+          "config": {
+            "template": {
+              "name": "\"hello_template\"",
+              "language": {
+                "code": "\"eng\""
+              },
+              "components": [
+                {
+                  "index": null,
+                  "type": "body",
+                  "parameters": [
+                    {
+                      "type": "text",
+                      "text": "\"Jane\"",
+                      "language": "eng"
+                    },
+                    {
+                      "type": "text",
+                      "text": "\"My Journey\"",
+                      "language": "eng"
+                    },
+                    {
+                      "type": "text",
+                      "text": "\"Мінае\"",
+                      "language": "bel"
+                    },
+                    {
+                      "type": "text",
+                      "text": "\"завуч\"",
+                      "language": "bel"
+                    },
+                    {
+                      "type": "text",
+                      "text": "\"Мінае\"",
+                      "language": "bel"
+                    }
+                  ],
+                  "sub_type": null
+                }
+              ],
+              "tracking": null
+            }
+          },
+          "tags": [],
+          "uuid": "70d4e9f9-457b-5dc0-b02e-064fb5af518e",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "card_whatsapp_template_message",
+              "config": {},
+              "test": "",
+              "uuid": "3a0816a6-4ee2-45d2-8143-541b1a49f973",
+              "destination_block": null,
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "code_generator": null,
+                      "condition": null,
+                      "meta": {
+                        "column": 3,
+                        "line": 2
+                      },
+                      "name": "Card",
+                      "uuid": "4d692c00-9ba9-54f9-a873-e3900b9eb5db",
+                      "version": null
+                    },
+                    "card_item": {
+                      "meta": {
+                        "column": 5,
+                        "line": 3
+                      },
+                      "type": "whatsapp_template_message",
+                      "whatsapp_template_message": {}
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "last_modified": "2025-05-20T01:10:15.397484Z",
+      "uuid": "97bb8384-30d4-4f16-8c85-4ef443bd6bab",
+      "languages": [
+        {
+          "id": "41c4a46b-baa5-45fb-b574-1cd8c6419eab",
+          "label": "English",
+          "variant": null,
+          "iso_639_3": "eng",
+          "bcp_47": null
+        },
+	{
+          "id": "41c4a46b-baa5-45fb-b574-1cd8c6419eab",
+          "label": "Belarusian",
+          "variant": null,
+          "iso_639_3": "bel",
+          "bcp_47": null
+        }
+      ],
+      "first_block_id": "70d4e9f9-457b-5dc0-b02e-064fb5af518e",
+      "interaction_timeout": 300,
+      "vendor_metadata": {},
+      "supported_modes": [
+        "RICH_MESSAGING"
+      ],
+      "exit_block_id": ""
+    }
+  ],
+  "vendor_metadata": {},
+  "specification_version": "1.0.0-rc3"
+}

--- a/test/simulator_test.exs
+++ b/test/simulator_test.exs
@@ -3,24 +3,24 @@ defmodule FlowRunner.SimulatorTest do
   alias FlowRunner.Simulator
 
   @spec read_floip!(name :: String.t()) :: FlowRunner.Spec.Container.t()
-  def read_floip!(name) do
+  defp read_floip!(name) do
     "priv/fixtures/test/simulator/#{name}.flow"
     |> File.read!()
     |> Jason.decode!()
     |> FlowRunner.compile!()
   end
 
-  def with_content_type(resource_value_outputs, content_type) do
+  defp with_content_type(resource_value_outputs, content_type) do
     resource_value_outputs
     |> Enum.filter(&(&1.content_type == content_type))
   end
 
-  def has_value(resource_value_outputs, value) do
+  defp has_value(resource_value_outputs, value) do
     Enum.any?(resource_value_outputs, &(&1.value =~ value)) ||
       flunk("Did not find #{inspect(value)} in #{inspect(resource_value_outputs)}")
   end
 
-  def has_values(resource_value_outputs, values) do
+  defp has_values(resource_value_outputs, values) do
     values
     |> Enum.reduce(resource_value_outputs, fn value, resource_values_outputs ->
       Enum.reject(resource_values_outputs, &(&1.value =~ value))
@@ -714,6 +714,28 @@ defmodule FlowRunner.SimulatorTest do
            |> get_in([:message, :text])
            |> with_content_type("TEXT")
            |> has_value("This is card 1")
+  end
+
+  test "whatsapp template message with translations using default language" do
+    sim = Simulator.new(read_floip!("whatsapp_template_message_with_translations"))
+
+    {:end, sim, outputs} = Simulator.start(sim)
+
+    assert outputs
+           |> get_in([:message, :text])
+           |> with_content_type("TEXT")
+           |> has_value("Body parameters: [Jane, My Journey]")
+  end
+
+  test "whatsapp template message using translations" do
+    sim = Simulator.new(read_floip!("whatsapp_template_message_with_translations"))
+
+    {:end, sim, outputs} = Simulator.start(sim, %{}, "bel")
+
+    assert outputs
+           |> get_in([:message, :text])
+           |> with_content_type("TEXT")
+           |> has_value("Body parameters: [Мінае, завуч, Мінае]")
   end
 
   test "whatsapp template message with buttons not matching user input" do


### PR DESCRIPTION
This PR adds support to use translated WhatsApp template body params. 

It's not possible the existing `FlowRunner.Spec.ResourceValue` struct for WhatsApp templates because template variables are not directly translations of the default template language, for example the template body in English is `Hello {{1}}, nice to meet you, my name is {{2}}` and in Spanish is `Hola {{1}}, puedo ayudarte con {{2}}, mi nombre es {{3}}`, this means that the translation version of the template could have a different number of parameters and a different context.

Language for other parameters will be added in a follow up PR
