### PR TITLE
fix(simulator): include simulation state in error responses

### DIFF
--- a/lib/flow_runner/simulator.ex
+++ b/lib/flow_runner/simulator.ex
@@ -88,11 +88,11 @@ defmodule FlowRunner.Simulator do
   @spec next(t(), String.t() | nil, list, non_neg_integer) ::
           {:end, t(), list}
           | {:waiting, t(), list}
-          | {:error, reason :: String.t()}
+          | {:error, t(), reason :: String.t()}
   def next(sim, user_input \\ nil, acc \\ [], recursion \\ 0)
 
-  def next(_sim, _user_input, _acc, recursion) when recursion > @max_recursion do
-    {:error, "Exceeded max recursion calls allowed (#{@max_recursion})"}
+  def next(sim, _user_input, _acc, recursion) when recursion > @max_recursion do
+    {:error, sim, "Exceeded max recursion calls allowed (#{@max_recursion})"}
   end
 
   def next(sim, user_input, acc, recursion) do
@@ -140,7 +140,7 @@ defmodule FlowRunner.Simulator do
         {:end, sim, Enum.reverse(acc)}
 
       {:error, reason} when is_binary(reason) ->
-        {:error, reason}
+        {:error, sim, reason}
     end
   end
 

--- a/lib/flow_runner/spec/container.ex
+++ b/lib/flow_runner/spec/container.ex
@@ -45,6 +45,8 @@ defmodule FlowRunner.Spec.Container do
     end
   end
 
+  @spec fetch_flow_by_uuid(Container.t(), String.t()) ::
+          {:ok, Container.t(), FlowRunner.Spec.Flow.t()} | {:error, String.t()}
   def fetch_flow_by_uuid(%Container{flows: flows} = container, uuid) do
     case Enum.find(flows, &(&1.uuid == uuid)) do
       nil -> {:error, "no matching flow"}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule FlowRunner.MixProject do
   use Mix.Project
 
-  @version "5.24.1"
+  @version "6.0.0"
 
   def project do
     [

--- a/test/simulator_test.exs
+++ b/test/simulator_test.exs
@@ -48,8 +48,10 @@ defmodule FlowRunner.SimulatorTest do
   end
 
   test "simulator with infinite recursion" do
-    assert "infinite_recursion" |> read_floip!() |> Simulator.new() |> Simulator.start() ==
-             {:error, "Exceeded max recursion calls allowed (1000)"}
+    assert {:error, sim, "Exceeded max recursion calls allowed (1000)"} =
+             "infinite_recursion" |> read_floip!() |> Simulator.new() |> Simulator.start()
+
+    assert sim.context.last_block_uuid
   end
 
   test "simulator with log output" do


### PR DESCRIPTION
This is a follow up PR of: https://github.com/turnhub/flow_runner/pull/265 to return the simulator context.

Previously, when the simulator encountered errors, error responses only returned a reason string. This patch modifies the `next/4` function to include the current simulation state (`sim`) in error responses. This change ensures error handling provides more context, which may be valuable for debugging and better error responses.

Additionally, related test cases in `simulator_test.exs` were updated to assert the presence of the simulation state in the error responses. A new assertion verifies that the simulation context (`sim.context`) is accessible even in error scenarios.

BREAKING CHANGE: `next/4` previously returned error tuples without the simulation state now is expect the additional `sim` element in the error response structure.
