### PR TITLE
feat: add language to buttons in WhatsApp message templates

### DIFF
--- a/lib/flow_runner/custom_blocks/whatsapp_template_message.ex
+++ b/lib/flow_runner/custom_blocks/whatsapp_template_message.ex
@@ -45,14 +45,16 @@ defmodule FlowRunner.CustomBlocks.WhatsAppTemplateMessage do
   defp parse_component(
          %{"type" => type, "parameters" => parameters} = component,
          default_language
-       ),
-       do: %{
-         type: type,
-         index: component["index"],
-         # required only for buttons
-         sub_type: component["sub_type"],
-         parameters: Enum.map(parameters, &parse_parameter(&1, default_language))
-       }
+       ) do
+    %{
+      type: type,
+      index: component["index"],
+      # required only for buttons
+      sub_type: component["sub_type"],
+      parameters:
+        Enum.map(parameters, &parse_parameter(&1, component["language"] || default_language))
+    }
+  end
 
   defp parse_parameter(%{"type" => "text", "text" => text} = component, default_language),
     do: %{

--- a/test/flow_runner/custom_blocks/whatsapp_template_message_test.exs
+++ b/test/flow_runner/custom_blocks/whatsapp_template_message_test.exs
@@ -3,6 +3,53 @@ defmodule FlowRunner.CustomBlocks.WhatsAppTemplateMessageTest do
 
   alias FlowRunner.CustomBlocks.WhatsAppTemplateMessage
 
+  describe "validate_config!/1 for button url" do
+    test "translated button url" do
+      config = %{
+        "template" => %{
+          "components" => [
+            %{
+              "index" => "0",
+              "parameters" => [
+                %{"language" => "bel", "text" => "\"bel\"", "type" => "text"}
+              ],
+              "sub_type" => "url",
+              "type" => "button"
+            },
+            %{
+              "index" => "0",
+              "parameters" => [
+                %{"language" => "en", "text" => "\"en\"", "type" => "text"}
+              ],
+              "sub_type" => "url",
+              "type" => "button"
+            }
+          ],
+          "language" => %{"code" => "\"en\""},
+          "name" => "\"hello_template\"",
+          "tracking" => nil
+        }
+      }
+
+      result = WhatsAppTemplateMessage.validate_config!(config)
+
+      assert [
+               %{
+                 index: "0",
+                 parameters: [%{type: "text", text: "\"bel\"", language: "bel"}],
+                 sub_type: "url",
+                 type: "button"
+               },
+               %{
+                 index: "0",
+                 parameters: [%{type: "text", text: "\"en\"", language: "en"}],
+                 sub_type: "url",
+                 type: "button"
+               }
+             ] = result.template.components
+    end
+  end
+
   describe "validate_config!/1 for document parameter" do
     test "returns document with filename when present" do
       config = %{


### PR DESCRIPTION
Add support for multiple languages in WhatsApp Message Template buttons.

This work was done for [media header params](https://github.com/turnhub/flow_runner/pull/264) and [body params](https://github.com/turnhub/flow_runner/pull/263) in templates in previous PRs:
#264
#263
