### PR TITLE
Add Wait custom block

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ by adding `flow_runner` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:flow_runner, "~> 5.23.4"}
+    {:flow_runner, "~> 6.1.0"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ by adding `flow_runner` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:flow_runner, "~> 6.1.0"}
+    {:flow_runner, "~> 6.2.0"}
   ]
 end
 ```

--- a/lib/flow_runner/blocks.ex
+++ b/lib/flow_runner/blocks.ex
@@ -29,7 +29,8 @@ defmodule FlowRunner.Blocks do
       "Io.Turn.UpdateDictionary" => FlowRunner.CustomBlocks.UpdateDictionary,
       "Io.Turn.WhatsAppSendFlow" => FlowRunner.CustomBlocks.WhatsAppSendFlow,
       "Io.Turn.WhatsAppTemplateMessage" => FlowRunner.CustomBlocks.WhatsAppTemplateMessage,
-      "Io.Turn.Webhook" => FlowRunner.CustomBlocks.Webhook
+      "Io.Turn.Webhook" => FlowRunner.CustomBlocks.Webhook,
+      "Io.Turn.Wait" => FlowRunner.CustomBlocks.Wait
     }
   end
 end

--- a/lib/flow_runner/custom_blocks/wait.ex
+++ b/lib/flow_runner/custom_blocks/wait.ex
@@ -1,0 +1,52 @@
+defmodule FlowRunner.CustomBlocks.Wait do
+  @moduledoc """
+  A Wait block type to introduce delays in Journey flows.
+
+  This block allows introducing delays in Journey flows to control timing
+  between actions.
+
+  ## Configuration
+
+  The block expects the following configuration:
+  - `seconds`: The number of seconds to wait (supports expressions)
+
+  ## Example Usage
+
+  ```
+  card MyCard do
+    wait(1)  # Wait for 1 second
+    text("This message appears after the delay")
+  end
+  ```
+  """
+
+  @behaviour FlowRunner.Spec.Block
+
+  @impl FlowRunner.Spec.Block
+  def validate_config!(%{"seconds" => seconds}) when is_integer(seconds) or is_binary(seconds) do
+    %{seconds: seconds}
+  end
+
+  def validate_config!(config) do
+    raise ArgumentError, """
+    Invalid Wait block configuration: #{inspect(config)}
+
+    Expected configuration:
+    %{
+      "seconds" => "5"  # String containing seconds to wait
+    }
+    """
+  end
+
+  @impl FlowRunner.Spec.Block
+  def evaluate_incoming(container, flow, block, context) do
+    # Wait blocks don't process incoming data, they just pass through
+    {:ok, container, flow, block, %{context | last_block_uuid: block.uuid}}
+  end
+
+  @impl FlowRunner.Spec.Block
+  def evaluate_outgoing(_container, _flow, _block, _context, user_input) do
+    # Wait blocks don't process outgoing data, they just pass through
+    {:ok, user_input}
+  end
+end

--- a/lib/flow_runner/simulator.ex
+++ b/lib/flow_runner/simulator.ex
@@ -558,14 +558,16 @@ defmodule FlowRunner.Simulator do
   def output_block(sim, %{type: "Io.Turn.Wait", config: %{seconds: seconds}}) do
     evaluated_seconds =
       if is_binary(seconds) do
-        Expression.evaluate_block!(seconds, sim.context.vars, sim.callbacks_module)
+        seconds
+        |> Expression.evaluate_block!(sim.context.vars, sim.callbacks_module)
+        |> String.to_integer()
       else
         seconds
       end
 
     debug_value = """
     [DEBUG]
-    Wait block: Pausing execution for #{evaluated_seconds} second(s).
+    Paused execution for #{evaluated_seconds} second(s).
     """
 
     # Wait for the number of seconds specified in the wait block

--- a/lib/flow_runner/simulator.ex
+++ b/lib/flow_runner/simulator.ex
@@ -555,6 +555,32 @@ defmodule FlowRunner.Simulator do
     {{:message, text: content_resource_outputs}, sim}
   end
 
+  def output_block(sim, %{type: "Io.Turn.Wait", config: %{seconds: seconds}}) do
+    evaluated_seconds =
+      if is_binary(seconds) do
+        Expression.evaluate_block!(seconds, sim.context.vars, sim.callbacks_module)
+      else
+        seconds
+      end
+
+    debug_value = """
+    [DEBUG]
+    Wait block: Pausing execution for #{evaluated_seconds} second(s).
+    """
+
+    # Wait for the number of seconds specified in the wait block
+    Process.sleep(evaluated_seconds * 1000)
+
+    text_output = %Output{
+      mime_type: "text/plain",
+      raw_value: debug_value,
+      value: debug_value,
+      content_type: "TEXT"
+    }
+
+    {{:message, text: [text_output]}, sim}
+  end
+
   def output_block(sim, %{type: type}) do
     Logger.info("Simulator unable to output block of type #{inspect(type)}")
     {nil, sim}

--- a/lib/flow_runner/simulator.ex
+++ b/lib/flow_runner/simulator.ex
@@ -558,9 +558,7 @@ defmodule FlowRunner.Simulator do
   def output_block(sim, %{type: "Io.Turn.Wait", config: %{seconds: seconds}}) do
     evaluated_seconds =
       if is_binary(seconds) do
-        seconds
-        |> Expression.evaluate_block!(sim.context.vars, sim.callbacks_module)
-        |> String.to_integer()
+        Expression.evaluate_block!(seconds, sim.context.vars, sim.callbacks_module)
       else
         seconds
       end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule FlowRunner.MixProject do
   use Mix.Project
 
-  @version "6.0.0"
+  @version "6.1.0"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule FlowRunner.MixProject do
   use Mix.Project
 
-  @version "6.1.0"
+  @version "6.2.0"
 
   def project do
     [

--- a/priv/fixtures/test/simulator/wait.flow
+++ b/priv/fixtures/test/simulator/wait.flow
@@ -29,7 +29,7 @@
           "semantic_label": "",
           "type": "Io.Turn.Wait",
           "config": {
-            "seconds": "1"
+            "seconds": 1
           },
           "exits": [
             {

--- a/priv/fixtures/test/simulator/wait.flow
+++ b/priv/fixtures/test/simulator/wait.flow
@@ -1,0 +1,81 @@
+{
+  "specification_version": "1.0.0-rc3",
+  "uuid": "e8c2b2b3-7c8c-4c8c-8c8c-8c8c8c8c8c8c",
+  "name": "Wait Block Test",
+  "description": "A simple flow to test the Wait block in simulator",
+  "vendor_metadata": {},
+  "flows": [
+    {
+      "uuid": "62d0084d-e88f-48c3-ac64-7a15855f0a43",
+      "name": "main",
+      "label": "Main flow",
+      "last_modified": "2020-01-01T00:00:00.000000Z",
+      "interaction_timeout": 300000,
+      "vendor_metadata": {},
+      "supported_modes": ["RICH_MESSAGING"],
+      "languages": [
+        {
+          "id": "eng",
+          "label": "English",
+          "iso_639_3": "eng"
+        }
+      ],
+      "first_block_id": "4d73864d-f579-4c72-81ea-0a38f4195228",
+      "blocks": [
+        {
+          "uuid": "4d73864d-f579-4c72-81ea-0a38f4195228",
+          "name": "Wait 1 seconds",
+          "label": "Wait Block",
+          "semantic_label": "",
+          "type": "Io.Turn.Wait",
+          "config": {
+            "seconds": "1"
+          },
+          "exits": [
+            {
+              "uuid": "0d26c2d1-eaa1-4a73-aff7-a5ce9d637b5e",
+              "name": "Default",
+              "semantic_label": "",
+              "destination_block": "6b7b6a49-ecfb-4712-b2c1-1c57c3c4e5a8",
+              "test": "",
+              "default": true
+            }
+          ]
+        },
+        {
+          "uuid": "6b7b6a49-ecfb-4712-b2c1-1c57c3c4e5a8",
+          "name": "After wait message",
+          "label": "Message Block",
+          "semantic_label": "",
+          "type": "MobilePrimitives.Message",
+          "config": {
+            "prompt": "b5bbda7e-41c8-46aa-a21e-7b5c1e4f8d92"
+          },
+          "exits": [
+            {
+              "uuid": "f7a8c9b2-3e5d-4f6a-8b9c-1d2e3f4a5b6c",
+              "name": "Default",
+              "semantic_label": "",
+              "test": "",
+              "default": true
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "uuid": "b5bbda7e-41c8-46aa-a21e-7b5c1e4f8d92",
+      "values": [
+        {
+          "language_id": "eng",
+          "content_type": "TEXT",
+          "mime_type": "text/plain",
+          "modes": ["RICH_MESSAGING"],
+          "value": "This message appears after the wait!"
+        }
+      ]
+    }
+  ]
+}

--- a/test/flow_runner/simulator_test.exs
+++ b/test/flow_runner/simulator_test.exs
@@ -1043,7 +1043,7 @@ defmodule FlowRunner.SimulatorTest do
     assert {:message, wait_fields} = wait_output
     [wait_text] = get_in(wait_fields, [:text])
     assert wait_text.content_type == "TEXT"
-    assert wait_text.value =~ "Wait block: Pausing execution for 1 second(s)"
+    assert wait_text.value =~ "Paused execution for 1 second(s)"
 
     # Second output should be the message after wait
     assert {:message, message_fields} = message_output

--- a/test/flow_runner/simulator_test.exs
+++ b/test/flow_runner/simulator_test.exs
@@ -1028,4 +1028,27 @@ defmodule FlowRunner.SimulatorTest do
     # does NOT exists in the context variables
     assert get_in(sim.context.vars, ["variables", "platform"]) == nil
   end
+
+  test "simulator with wait block" do
+    sim = Simulator.new(read_floip!("wait"))
+
+    {:end, _sim, outputs} = Simulator.start(sim)
+
+    # Should have two messages: wait debug message and the actual message
+    assert length(outputs) == 2
+
+    # First output should be the wait block debug message
+    [wait_output, message_output] = outputs
+
+    assert {:message, wait_fields} = wait_output
+    [wait_text] = get_in(wait_fields, [:text])
+    assert wait_text.content_type == "TEXT"
+    assert wait_text.value =~ "Wait block: Pausing execution for 1 second(s)"
+
+    # Second output should be the message after wait
+    assert {:message, message_fields} = message_output
+    [message_text] = get_in(message_fields, [:text])
+    assert message_text.content_type == "TEXT"
+    assert message_text.value == "This message appears after the wait!"
+  end
 end

--- a/test/flow_runner/simulator_test.exs
+++ b/test/flow_runner/simulator_test.exs
@@ -1043,7 +1043,11 @@ defmodule FlowRunner.SimulatorTest do
     assert {:message, wait_fields} = wait_output
     [wait_text] = get_in(wait_fields, [:text])
     assert wait_text.content_type == "TEXT"
-    assert wait_text.value =~ "Paused execution for 1 second(s)"
+
+    assert wait_text.value == """
+           [DEBUG]
+           Paused execution for 1 second(s).
+           """
 
     # Second output should be the message after wait
     assert {:message, message_fields} = message_output


### PR DESCRIPTION
# Add Wait Block

## Overview
This PR adds support for the `Io.Turn.Wait` block in the FlowRunner, enabling flows to introduce delays during execution.

## Technical Details

### Wait Block Configuration
```elixir
config: %{
  seconds: 1  # Can be integer or expression string
}
```

### Simulator Behavior
- **Input**: Accepts `seconds` configuration (integer or expression)
- **Processing**: Evaluates expressions and implements actual delay
- **Output**: Debug message + continues to next block
- **Delay**: Uses `Process.sleep(seconds * 1000)` for realistic timing

### Example Output
```
[DEBUG]
Paused execution for 1 second(s).
```