### PR TITLE
Update WhatsApp Catalog Block to Wait for User Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ by adding `flow_runner` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:flow_runner, "~> 6.3.0"}
+    {:flow_runner, "~> 6.3.1"}
   ]
 end
 ```

--- a/lib/flow_runner/custom_blocks/whatsapp_catalog.ex
+++ b/lib/flow_runner/custom_blocks/whatsapp_catalog.ex
@@ -61,8 +61,8 @@ defmodule FlowRunner.CustomBlocks.WhatsAppCatalog do
     context = %{
       context
       | last_block_uuid: block.uuid,
-        # catalog messages are display-only, they don't wait for user input
-        waiting_for_user_input: false
+        # catalog messages wait for user input (place order)
+        waiting_for_user_input: true
     }
 
     {:ok, container, flow, block, context}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule FlowRunner.MixProject do
   use Mix.Project
 
-  @version "6.3.0"
+  @version "6.3.1"
 
   def project do
     [

--- a/test/flow_runner/custom_blocks/whatsapp_catalog_test.exs
+++ b/test/flow_runner/custom_blocks/whatsapp_catalog_test.exs
@@ -104,14 +104,14 @@ defmodule FlowRunner.CustomBlocks.WhatsAppCatalogTest do
   end
 
   describe "evaluate_incoming/4" do
-    test "sets waiting_for_user_input to false and updates last_block_uuid" do
+    test "sets waiting_for_user_input to true and updates last_block_uuid" do
       container = %{}
       flow = %{}
       block = %{uuid: "test-block-uuid"}
 
       context = %{
         last_block_uuid: "previous-uuid",
-        waiting_for_user_input: true
+        waiting_for_user_input: false
       }
 
       {:ok, returned_container, returned_flow, returned_block, returned_context} =
@@ -121,7 +121,7 @@ defmodule FlowRunner.CustomBlocks.WhatsAppCatalogTest do
       assert returned_flow == flow
       assert returned_block == block
       assert returned_context.last_block_uuid == "test-block-uuid"
-      assert returned_context.waiting_for_user_input == false
+      assert returned_context.waiting_for_user_input == true
     end
 
     test "preserves other context fields while updating specific ones" do
@@ -131,7 +131,7 @@ defmodule FlowRunner.CustomBlocks.WhatsAppCatalogTest do
 
       context = %{
         last_block_uuid: "old-uuid",
-        waiting_for_user_input: true,
+        waiting_for_user_input: false,
         some_other_field: "preserved_value",
         another_field: 42
       }
@@ -140,7 +140,7 @@ defmodule FlowRunner.CustomBlocks.WhatsAppCatalogTest do
         WhatsAppCatalog.evaluate_incoming(container, flow, block, context)
 
       assert returned_context.last_block_uuid == "catalog-block-uuid"
-      assert returned_context.waiting_for_user_input == false
+      assert returned_context.waiting_for_user_input == true
       assert returned_context.some_other_field == "preserved_value"
       assert returned_context.another_field == 42
     end

--- a/test/flow_runner/simulator_test.exs
+++ b/test/flow_runner/simulator_test.exs
@@ -1047,7 +1047,7 @@ defmodule FlowRunner.SimulatorTest do
   test "whatsapp catalog with text only" do
     sim = Simulator.new(read_floip!("whatsapp_catalog_basic"))
 
-    {:end, _sim, outputs} = Simulator.start(sim)
+    {:waiting, _sim, outputs} = Simulator.start(sim)
 
     # Check the catalog message text
     assert outputs
@@ -1075,7 +1075,7 @@ defmodule FlowRunner.SimulatorTest do
   test "whatsapp catalog with text and footer" do
     sim = Simulator.new(read_floip!("whatsapp_catalog_with_footer"))
 
-    {:end, _sim, outputs} = Simulator.start(sim)
+    {:waiting, _sim, outputs} = Simulator.start(sim)
 
     # Check the main catalog message
     assert outputs
@@ -1104,7 +1104,7 @@ defmodule FlowRunner.SimulatorTest do
   test "whatsapp catalog with expressions in text and footer" do
     sim = Simulator.new(read_floip!("whatsapp_catalog_with_expressions"))
 
-    {:end, _sim, outputs} =
+    {:waiting, _sim, outputs} =
       Simulator.start(sim, %{"store_name" => "Amazing Store", "support_email" => "help@store.com"})
 
     # Check that expressions are evaluated in the catalog text


### PR DESCRIPTION
This PR updates the WhatsAppCatalog block behavior to wait for user input, making it consistent with other interactive WhatsApp blocks like WhatsAppRequestLocation.

Previously, catalog messages were handled as display-only and would immediately proceed to the next block. Now, we want them to wait for user interaction (such as placing an order from the catalog) before continuing the flow, which provides a more realistic user experience for e-commerce scenarios.

Core Logic Changes:

- Changed waiting_for_user_input from false to true in evaluate_incoming/4
- Updated the comment to reflect the new behavior: "catalog messages wait for user input (place order)"