### PR TITLE
Update to Elixir 1.19.0 and OTP 28 with improved type specs

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir-version: "1.18.4"
-            otp-version: "27"
+          - elixir-version: "1.19.0"
+            otp-version: "28"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -12,8 +12,8 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: "1.18.4"
-          otp-version: "27"
+          elixir-version: "1.19.0"
+          otp-version: "28"
       - name: Install Dependencies
         run: |
           mix local.hex --force

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.18.4-otp-27
-erlang 27.0
+elixir 1.19.0-otp-28
+erlang 28.1

--- a/lib/flow_runner/custom_blocks/update_dictionary.ex
+++ b/lib/flow_runner/custom_blocks/update_dictionary.ex
@@ -17,7 +17,7 @@ defmodule FlowRunner.CustomBlocks.UpdateDictionary do
 
   @impl true
   @decorate with_span("DSL.Blocks.UpdateDictionary.evaluate_incoming")
-  def evaluate_incoming(container, flow, block, context) do
+  def evaluate_incoming(container, flow, block, %FlowRunner.Context{} = context) do
     context = %FlowRunner.Context{
       context
       | waiting_for_user_input: false,

--- a/lib/flow_runner/spec/block.ex
+++ b/lib/flow_runner/spec/block.ex
@@ -138,7 +138,7 @@ defmodule FlowRunner.Spec.Block do
     {:ok, context}
   end
 
-  def evaluate_user_input(block, context, user_input)
+  def evaluate_user_input(block, %Context{} = context, user_input)
       when context.waiting_for_user_input == true do
     vars =
       Map.merge(context.vars, %{
@@ -149,7 +149,7 @@ defmodule FlowRunner.Spec.Block do
     {:ok, %Context{context | vars: vars, waiting_for_user_input: false}}
   end
 
-  def evaluate_user_input(%{type: "Core.Case"} = block, context, user_input) do
+  def evaluate_user_input(%{type: "Core.Case"} = block, %Context{} = context, user_input) do
     vars =
       Map.merge(context.vars, %{
         "block" => %{"value" => user_input},

--- a/lib/flow_runner/spec/blocks/log.ex
+++ b/lib/flow_runner/spec/blocks/log.ex
@@ -27,7 +27,7 @@ defmodule FlowRunner.Spec.Blocks.Log do
         %Container{} = container,
         %Flow{} = flow,
         %Block{} = block,
-        context
+        %Context{} = context
       ) do
     context =
       case Container.fetch_resource_by_uuid(container, block.config.message) do

--- a/lib/flow_runner/spec/blocks/message.ex
+++ b/lib/flow_runner/spec/blocks/message.ex
@@ -25,7 +25,7 @@ defmodule FlowRunner.Spec.Blocks.Message do
 
   @impl true
   @decorate with_span("FlowRunner.Blocks.Message.evaluate_incoming")
-  def evaluate_incoming(container, %Flow{} = flow, %Block{} = block, context) do
+  def evaluate_incoming(container, %Flow{} = flow, %Block{} = block, %Context{} = context) do
     {
       :ok,
       container,

--- a/lib/flow_runner/spec/blocks/numeric_response.ex
+++ b/lib/flow_runner/spec/blocks/numeric_response.ex
@@ -35,7 +35,7 @@ defmodule FlowRunner.Spec.Blocks.NumericResponse do
 
   @impl true
   @decorate with_span("FlowRunner.Blocks.NumericResponse.evaluate_incoming")
-  def evaluate_incoming(container, flow, block, context) do
+  def evaluate_incoming(container, flow, block, %Context{} = context) do
     {
       :ok,
       container,

--- a/lib/flow_runner/spec/blocks/open_response.ex
+++ b/lib/flow_runner/spec/blocks/open_response.ex
@@ -33,7 +33,7 @@ defmodule FlowRunner.Spec.Blocks.OpenResponse do
 
   @impl true
   @decorate with_span("FlowRunner.Blocks.OpenResponse.evaluate_incoming")
-  def evaluate_incoming(container, flow, block, context) do
+  def evaluate_incoming(container, flow, block, %Context{} = context) do
     {
       :ok,
       container,

--- a/lib/flow_runner/spec/blocks/select_one_response.ex
+++ b/lib/flow_runner/spec/blocks/select_one_response.ex
@@ -93,7 +93,7 @@ defmodule FlowRunner.Spec.Blocks.SelectOneResponse do
 
   @impl true
   @decorate with_span("FlowRunner.Blocks.SelectOneResponse.evaluate_incoming")
-  def evaluate_incoming(container, flow, block, context) do
+  def evaluate_incoming(container, flow, block, %Context{} = context) do
     {
       :ok,
       container,

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule FlowRunner.MixProject do
       app: :flow_runner,
       aliases: aliases(),
       version: @version,
-      elixir: "~> 1.13",
+      elixir: "~> 1.16",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:yecc] ++ Mix.compilers(),
       description: description(),

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,4 @@
+{ pkgs ? import <nixpkgs> {} }:
+  pkgs.mkShell {
+    nativeBuildInputs = with pkgs.buildPackages; [ beam28Packages.elixir_1_19 ];
+}


### PR DESCRIPTION
## Summary
- Upgrades Elixir from 1.18.4 to 1.19.0
- Upgrades Erlang/OTP from 27.0 to 28.1

## Motivation
This upgrade ensures we're using the latest Elixir and OTP versions, which provide performance improvements

---

Added a `shell.nix` to have a declarative way to install Elixir in the project for nix users, usage:
```bash
$ nix shell
$ elixir --version
Erlang/OTP 28 [erts-16.1] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]

Elixir 1.19.0-rc.2 (compiled with Erlang/OTP 28)
```
