### PR TITLE
Add payload rendering to WhatsAppSendFlow simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ by adding `flow_runner` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:flow_runner, "~> 6.5.0"}
+    {:flow_runner, "~> 6.5.1"}
   ]
 end
 ```

--- a/lib/flow_runner/simulator.ex
+++ b/lib/flow_runner/simulator.ex
@@ -295,7 +295,7 @@ defmodule FlowRunner.Simulator do
     payload = get_vendor(vendor_metadata, ["card_item", "whatsapp_flow", "payload"])
 
     payload_output =
-      if payload not in [nil, %{}, ""] do
+      if payload && payload != %{} && payload != "" do
         evaluated_payload =
           evaluate_conversion_fields(payload, sim.context.vars, sim.callbacks_module)
 

--- a/lib/flow_runner/simulator.ex
+++ b/lib/flow_runner/simulator.ex
@@ -272,7 +272,8 @@ defmodule FlowRunner.Simulator do
             cta: cta_resource_uuid,
             screen: screen
           }
-        }
+        },
+        vendor_metadata: vendor_metadata
       }) do
     flow_id = Expression.evaluate_as_string!(flow_id, sim.context.vars, sim.callbacks_module)
 
@@ -290,10 +291,23 @@ defmodule FlowRunner.Simulator do
       |> fetch_resource_values(cta_resource, "TEXT")
       |> Enum.map(&resource_value_output(sim, &1))
 
+    # Extract and evaluate payload if present
+    payload = get_vendor(vendor_metadata, ["card_item", "whatsapp_flow", "payload"])
+
+    payload_output =
+      if payload not in [nil, %{}, ""] do
+        evaluated_payload =
+          evaluate_conversion_fields(payload, sim.context.vars, sim.callbacks_module)
+
+        "\n    Payload: #{inspect(evaluated_payload)}"
+      else
+        ""
+      end
+
     debug_value = """
     [DEBUG]
     Flow with ID #{inspect(flow_id)} is sent to the phone using #{inspect(cta.value)} as the call to action.
-    It will start with the screen #{inspect(screen)}.
+    It will start with the screen #{inspect(screen)}.#{payload_output}
 
     Note: it won't actually run in this simulator.
     """

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule FlowRunner.MixProject do
   use Mix.Project
 
-  @version "6.5.0"
+  @version "6.5.1"
 
   def project do
     [

--- a/priv/fixtures/test/simulator/whatsapp_send_flow_no_payload.flow
+++ b/priv/fixtures/test/simulator/whatsapp_send_flow_no_payload.flow
@@ -1,0 +1,111 @@
+{
+  "name": "WhatsApp Send Flow No Payload",
+  "description": "WhatsApp flow message test without payload",
+  "uuid": "d4b3810f-00d3-492e-92bd-75b0670d5ea8",
+  "flows": [
+    {
+      "uuid": "48da8ae9-0272-4ebf-8f30-fff28eeaf3d0",
+      "name": "WhatsApp Send Flow No Payload",
+      "label": null,
+      "last_modified": "2025-11-12T15:46:52.158515Z",
+      "interaction_timeout": 300,
+      "vendor_metadata": {},
+      "supported_modes": ["RICH_MESSAGING"],
+      "first_block_id": "e98b60d8-eaae-5fd4-a260-77a20549207c",
+      "exit_block_id": "",
+      "languages": [
+        {
+          "id": "57e46c33-bdb5-44cb-a707-11b89d1e6f7a",
+          "iso_639_3": "eng",
+          "label": "English",
+          "variant": null,
+          "bcp_47": null
+        }
+      ],
+      "blocks": [
+        {
+          "uuid": "e98b60d8-eaae-5fd4-a260-77a20549207c",
+          "name": "flow_whatsapp_flow_no_payload",
+          "label": null,
+          "semantic_label": null,
+          "tags": [],
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "code_generator": null,
+                      "condition": null,
+                      "meta": {"column": 3, "line": 2},
+                      "name": "Flow",
+                      "uuid": "181e9c45-45fd-5bb9-888a-00238f501ce3",
+                      "version": null
+                    },
+                    "card_item": {
+                      "meta": {"column": 5, "line": 4},
+                      "type": "whatsapp_flow",
+                      "whatsapp_flow": {}
+                    },
+                    "index": 0,
+                    "version": 2.0
+                  }
+                }
+              }
+            }
+          },
+          "ui_metadata": {"canvas_coordinates": {"x": 0, "y": 0}},
+          "type": "Io.Turn.WhatsAppSendFlow",
+          "config": {
+            "flow": {
+              "id": "9876543210",
+              "text": "2ce61ee7-27a2-4d7f-b797-4282674e6e20",
+              "screen": "HOME",
+              "cta": "241daa6a-26ae-4cde-bcdf-07188e4a79d3"
+            }
+          },
+          "exits": [
+            {
+              "uuid": "47a40874-5531-45bc-b585-2f748a3905a7",
+              "name": "flow_whatsapp_flow_no_payload",
+              "destination_block": null,
+              "semantic_label": "",
+              "test": "",
+              "default": true,
+              "config": {},
+              "vendor_metadata": {}
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "uuid": "241daa6a-26ae-4cde-bcdf-07188e4a79d3",
+      "values": [
+        {
+          "language_id": "57e46c33-bdb5-44cb-a707-11b89d1e6f7a",
+          "content_type": "TEXT",
+          "mime_type": "text/plain",
+          "modes": ["RICH_MESSAGING"],
+          "value": "Open Flow"
+        }
+      ]
+    },
+    {
+      "uuid": "2ce61ee7-27a2-4d7f-b797-4282674e6e20",
+      "values": [
+        {
+          "language_id": "57e46c33-bdb5-44cb-a707-11b89d1e6f7a",
+          "content_type": "TEXT",
+          "mime_type": "text/plain",
+          "modes": ["RICH_MESSAGING"],
+          "value": "Check out our flow"
+        }
+      ]
+    }
+  ],
+  "description": "WhatsApp flow message test without payload",
+  "specification_version": "1.0.0-rc3"
+}

--- a/test/flow_runner/simulator_test.exs
+++ b/test/flow_runner/simulator_test.exs
@@ -83,6 +83,30 @@ defmodule FlowRunner.SimulatorTest do
            |> has_value(
              "Flow with ID \"1289489102445874\" is sent to the phone using \"click!\" as the call to action."
            )
+
+    # Assert payload is rendered
+    assert outputs
+           |> get_in([:message, :text])
+           |> with_content_type("TEXT")
+           |> has_value("Payload: %{\"foo\" => \"bar\"}")
+  end
+
+  test "simulator with whatsapp flow without payload" do
+    sim = Simulator.new(read_floip!("whatsapp_send_flow_no_payload"))
+    {:waiting, _sim, outputs} = Simulator.start(sim)
+
+    text_output =
+      outputs
+      |> get_in([:message, :text])
+      |> with_content_type("TEXT")
+      |> List.first()
+
+    # Assert basic flow info is present
+    assert text_output.value =~ "Flow with ID \"9876543210\""
+    assert text_output.value =~ "using \"Open Flow\" as the call to action"
+
+    # Assert payload is NOT present in output
+    refute text_output.value =~ "Payload:"
   end
 
   test "simulator with whatsapp request location" do


### PR DESCRIPTION
## Summary

The WhatsAppSendFlow simulator now displays payload information when present in the flow definition.

## Changes

- Updated `lib/flow_runner/simulator.ex` to extract and render payload from vendor_metadata
- Payload is normalized to handle JSON strings, maps, or lists
- Expression values in payload are evaluated (e.g., `@contact.name`)
- Payload is displayed using `inspect/1` for simple, readable formatting
- Only shown when payload is present and non-empty

## Example Output

```
[DEBUG]
Flow with ID "1289489102445874" is sent to the phone using "click!" as the call to action.
It will start with the screen "SIGN_UP".
    Payload: %{"foo" => "bar"}

Note: it won't actually run in this simulator.
```
<img width="338" height="642" alt="image" src="https://github.com/user-attachments/assets/2d85b123-ddaa-4241-b54e-88e4e14ee5f5" />
