### PR TITLE
Fix MetaConversion simulator to handle nested structures in optional fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ by adding `flow_runner` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:flow_runner, "~> 6.5.0"}
+    {:flow_runner, "~> 6.5.2"}
   ]
 end
 ```

--- a/lib/flow_runner/simulator.ex
+++ b/lib/flow_runner/simulator.ex
@@ -759,11 +759,26 @@ defmodule FlowRunner.Simulator do
   # Evaluate all values in a map as expressions
   defp evaluate_map_values(map, context_vars, callbacks_module) do
     Map.new(map, fn {key, value_expr} ->
-      evaluated_value =
-        Expression.evaluate_as_string!(to_string(value_expr), context_vars, callbacks_module)
+      evaluated_value = evaluate_field_value(value_expr, context_vars, callbacks_module)
 
       {key, evaluated_value}
     end)
+  end
+
+  # Evaluate a single field value - handles nested structures
+  defp evaluate_field_value(value, context_vars, callbacks_module) when is_map(value) do
+    evaluate_map_values(value, context_vars, callbacks_module)
+  end
+
+  defp evaluate_field_value(value, context_vars, callbacks_module) when is_list(value) do
+    # Convert keyword list to map and evaluate
+    value
+    |> Enum.into(%{})
+    |> evaluate_map_values(context_vars, callbacks_module)
+  end
+
+  defp evaluate_field_value(value, context_vars, callbacks_module) do
+    Expression.evaluate_as_string!(to_string(value), context_vars, callbacks_module)
   end
 
   defp extract_buttons(template_components, sim) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule FlowRunner.MixProject do
   use Mix.Project
 
-  @version "6.5.0"
+  @version "6.5.2"
 
   def project do
     [

--- a/priv/fixtures/test/simulator/meta_conversion_with_nested_fields.flow
+++ b/priv/fixtures/test/simulator/meta_conversion_with_nested_fields.flow
@@ -1,0 +1,63 @@
+{
+  "specification_version": "1.0.0-rc3",
+  "uuid": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+  "name": "Meta Conversion With Nested Fields Test",
+  "description": "A flow to test the Meta Conversion block with nested optional fields",
+  "vendor_metadata": {},
+  "flows": [
+    {
+      "uuid": "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
+      "name": "main",
+      "label": "Main flow",
+      "last_modified": "2020-01-01T00:00:00.000000Z",
+      "interaction_timeout": 300000,
+      "vendor_metadata": {},
+      "supported_modes": ["RICH_MESSAGING"],
+      "languages": [
+        {
+          "id": "eng",
+          "label": "English",
+          "iso_639_3": "eng"
+        }
+      ],
+      "first_block_id": "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f",
+      "blocks": [
+        {
+          "uuid": "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f",
+          "name": "Send Meta Conversion with nested fields",
+          "label": "Meta Conversion Block",
+          "semantic_label": "",
+          "type": "Io.Turn.MetaConversion",
+          "config": {
+            "conversion": {
+              "event_name": "Purchase",
+              "user_data": {
+                "client_ip_address": "1.1.1.1",
+                "client_user_agent": "test user agent"
+              },
+              "optional_fields": {
+                "value": "199.99",
+                "currency": "USD",
+                "custom_data": {
+                  "product_id": "SKU123",
+                  "category": "Electronics",
+                  "brand": "TestBrand"
+                }
+              }
+            }
+          },
+          "exits": [
+            {
+              "uuid": "d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a",
+              "name": "Default",
+              "semantic_label": "",
+              "test": "",
+              "default": true
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": []
+}

--- a/test/flow_runner/simulator_test.exs
+++ b/test/flow_runner/simulator_test.exs
@@ -1263,4 +1263,36 @@ defmodule FlowRunner.SimulatorTest do
     assert conversion_text.value =~
              ~s("event_source_url" => "https://example.com/products/widget")
   end
+
+  test "meta conversion with nested optional fields" do
+    sim = Simulator.new(read_floip!("meta_conversion_with_nested_fields"))
+
+    {:end, _sim, outputs} = Simulator.start(sim)
+
+    assert length(outputs) == 1
+
+    [conversion_output] = outputs
+
+    assert {:message, conversion_fields} = conversion_output
+    [conversion_text] = get_in(conversion_fields, [:text])
+    assert conversion_text.content_type == "TEXT"
+
+    # Check that the debug output contains the event name and user_data
+    assert conversion_text.value =~ "Meta Conversion event sent:"
+    assert conversion_text.value =~ "event_name: Purchase"
+    assert conversion_text.value =~ "user_data:"
+    assert conversion_text.value =~ ~s("client_ip_address" => "1.1.1.1")
+    assert conversion_text.value =~ ~s("client_user_agent" => "test user agent")
+
+    # Check that the debug output contains optional_fields with nested custom_data
+    assert conversion_text.value =~ "optional_fields:"
+    assert conversion_text.value =~ ~s("value" => "199.99")
+    assert conversion_text.value =~ ~s("currency" => "USD")
+
+    # Verify nested custom_data is properly evaluated and displayed
+    assert conversion_text.value =~ ~s("custom_data" =>)
+    assert conversion_text.value =~ ~s("product_id" => "SKU123")
+    assert conversion_text.value =~ ~s("category" => "Electronics")
+    assert conversion_text.value =~ ~s("brand" => "TestBrand")
+  end
 end


### PR DESCRIPTION
## Summary

The Simulator now correctly handles nested structures (maps and keyword lists) in optional_fields for MetaConversion block.

## Problem

Previously, when using nested structures in conversion fields, such as:
```elixir
conversion(
  "Test",
  [client_ip_address: "1.1.1.1", client_user_agent: "test user agent"],
  custom_data: [product_id: "SKU123", category: "Electronics"]
)
```
the simulator crashed with the error:
```
Journey execution failed: %{"category" => "Electronics", "product_id" => "SKU123"} is not a string
```

## Changes

- Refactored `evaluate_map_values/3` to use a new helper function
- Added `evaluate_field_value/3` to recursively handle:
  - Nested maps (evaluated recursively)
  - Keyword lists (converted to maps and evaluated)
  - Simple values (strings, numbers - evaluated as expressions)

## Example Output

```
[DEBUG]
Meta Conversion event sent:
  event_name: Purchase
  user_data: %{"client_ip_address" => "1.1.1.1", "client_user_agent" => "test user agent"}
  optional_fields: %{"currency" => "USD", "custom_data" => %{"brand" => "TestBrand", "category" => "Electronics", "product_id" => "SKU123"}, "value" => "199.99"}
```
<img width="265" height="261" alt="image" src="https://github.com/user-attachments/assets/9747a631-66fe-40b0-a4fa-746c4c731af7" />
