### PR TITLE
Fix guard clauses when used with complex results

### DIFF
--- a/lib/flow_runner/spec/exit.ex
+++ b/lib/flow_runner/spec/exit.ex
@@ -34,7 +34,7 @@ defmodule FlowRunner.Spec.Exit do
   def evaluate(exit, context) do
     test = exit.test || ""
 
-    case FlowRunner.evaluate_expression_block(test, context.vars) do
+    case FlowRunner.evaluate_expression_block(test, context.vars) |> extract_value() do
       other when not is_boolean(other) ->
         Logger.info(
           "Expression '#{exit.test}' returned #{inspect(other)} when expecting a boolean last_block_uuid=#{context.last_block_uuid}"
@@ -53,4 +53,8 @@ defmodule FlowRunner.Spec.Exit do
         boolean
     end
   end
+
+  # Extract __value__ from complex expression results
+  defp extract_value(%{"__value__" => value}), do: value
+  defp extract_value(other), do: other
 end

--- a/test/block_test.exs
+++ b/test/block_test.exs
@@ -164,4 +164,40 @@ defmodule BlockTest do
     assert {:ok, %Context{}, _no_destination_block = nil} =
              Block.fetch_next_block(block, %Flow{}, context)
   end
+
+  test "evaluate exits with complex values containing __value__" do
+    # When an expression returns a map with __value__ (like has_phone),
+    # the exit should extract and use the __value__ for boolean evaluation
+    context = %Context{
+      vars: %{
+        "valid" => %{"__value__" => true, "phonenumber" => "+27820001001"}
+      }
+    }
+
+    block = %Block{
+      exits: [
+        %Exit{
+          uuid: "success-exit",
+          test: "valid"
+        },
+        %Exit{
+          uuid: "failure-exit",
+          default: true
+        }
+      ]
+    }
+
+    # Should match the first exit because valid.__value__ is true
+    assert {:ok, %Exit{uuid: "success-exit"}} = Block.evaluate_exits(block, context)
+
+    # Test with __value__ = false
+    context_false = %Context{
+      vars: %{
+        "valid" => %{"__value__" => false, "phonenumber" => nil}
+      }
+    }
+
+    # Should fall through to default exit because valid.__value__ is false
+    assert {:ok, %Exit{uuid: "failure-exit"}} = Block.evaluate_exits(block, context_false)
+  end
 end


### PR DESCRIPTION
## Purpose

Fix conditional exit evaluation when expression functions return complex values instead of plain booleans.

Functions like has_phone, has_email, has_date, and other validation functions return rich result objects containing both a boolean __value__ and additional extracted data (e.g., the parsed phone number). When these results are stored in variables and used in conditional exits (then(Card when condition)), the exit evaluation fails because it expects a plain boolean rather than a map.

## Approach

Modified Exit.evaluate/2 to extract the __value__ from complex expression results before performing the boolean check. This follows the same pattern used elsewhere in the expression library where __value__ represents the "default" or primary value of a complex result.

Added a private extract_value/1 helper that:
- Returns the __value__ when given a map containing that key
- Passes through all other values unchanged

This allows journeys to use validation functions naturally in conditionals without requiring users to manually access the __value__ field.

<img width="1435" height="1008" alt="image" src="https://github.com/user-attachments/assets/bd542f24-04a6-4516-a8a1-2a5840ca8315" />