### PR TITLE
Change CLA signatures branch from develop to cla-signatures

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,7 +28,7 @@ jobs:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/turnhub/flow_runner/blob/develop/CLA.md" # e.g. a CLA or a DCO document
           # branch should not be protected
-          branch: "develop"
+          branch: "cla-signatures"
           allowlist: dependabot[bot]
 
           #below are the optional inputs - If the optional inputs are not given, then default values will be taken


### PR DESCRIPTION
## Summary
- Move CLA signature storage to a dedicated `cla-signatures` branch
- Prevents CLA Assistant from committing directly to the protected `develop` branch

## Test plan
- [ ] Verify the `cla-signatures` branch exists or will be created by the CLA Assistant
- [ ] Test that new CLA signatures are stored in the correct branch