### PR TITLE
[PROD-4484] Add automatic documentation generation for FLOIP blocks

### DIFF
--- a/lib/flow_runner/block_autodoc.ex
+++ b/lib/flow_runner/block_autodoc.ex
@@ -1,0 +1,77 @@
+defmodule FlowRunner.BlockAutodoc do
+  @moduledoc """
+  Compile-time documentation collection for FLOIP block modules.
+
+  This macro module enables automatic documentation generation for FLOIP blocks,
+  mirroring the pattern used by `Expression.Autodoc` for expression functions.
+
+  ## Usage
+
+  Add `use FlowRunner.BlockAutodoc` to any block module and annotate block types
+  with `@block_category` and `@block_doc` attributes:
+
+      defmodule FlowRunner.CustomBlocks.MyBlock do
+        use FlowRunner.BlockAutodoc
+
+        @block_category "control"
+        @block_doc type: "Io.Turn.MyBlock",
+                   dsl_name: "my_block()",
+                   description: "Does something useful.",
+                   config: %{
+                     "param" => %{type: "string", required: true, description: "A parameter"}
+                   },
+                   example: \"""
+                   card MyCard do
+                     my_block("value")
+                   end
+                   \"""
+
+        # ... block implementation
+      end
+
+  ## @block_doc Attribute Schema
+
+  | Field | Required | Description |
+  |-------|----------|-------------|
+  | `type` | Yes | Block type string (e.g., `"Io.Turn.Wait"`) |
+  | `dsl_name` | Yes | Human-readable name for docs (e.g., `"wait()"`) |
+  | `description` | Yes | Human-readable description |
+  | `config` | Yes | Map of config fields with type, required, description |
+  | `example` | No | DSL code example |
+  | `returns` | No | What the block sets in context |
+  | `notes` | No | Additional usage notes |
+  | `deprecated` | No | Boolean, marks deprecated blocks |
+  | `deprecated_in_favor_of` | No | Replacement block type |
+  | `deprecated_in_favor_of_dsl_name` | No | Replacement block dsl_name for display |
+
+  At compile time, this macro generates a `block_docs/0` function that returns
+  all documented blocks with their category attached.
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      Module.register_attribute(__MODULE__, :block_doc, accumulate: true)
+      Module.register_attribute(__MODULE__, :block_category, [])
+      @before_compile FlowRunner.BlockAutodoc
+    end
+  end
+
+  defmacro __before_compile__(env) do
+    block_docs = Module.get_attribute(env.module, :block_doc) || []
+    category = Module.get_attribute(env.module, :block_category)
+
+    quote do
+      @doc """
+      Returns all block documentation defined in this module.
+
+      Each block doc entry is a keyword list with keys like `:type`, `:description`,
+      `:config`, etc., plus a `:category` key added from `@block_category`.
+      """
+      @spec block_docs() :: [Keyword.t()]
+      def block_docs do
+        unquote(Macro.escape(block_docs))
+        |> Enum.map(fn doc -> Keyword.put(doc, :category, unquote(category)) end)
+      end
+    end
+  end
+end

--- a/lib/flow_runner/custom_blocks/meta_conversion.ex
+++ b/lib/flow_runner/custom_blocks/meta_conversion.ex
@@ -26,6 +26,35 @@ defmodule FlowRunner.CustomBlocks.MetaConversion do
 
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "integration"
+  @block_doc type: "Io.Turn.MetaConversion",
+             dsl_name: "conversion()",
+             description:
+               "Sends conversion events to Meta's Conversions API for ad optimization and measurement.",
+             config: %{
+               "conversion.event_name" => %{
+                 type: "string",
+                 required: true,
+                 description: "The conversion event name (e.g., \"Purchase\", \"Lead\")"
+               },
+               "conversion.user_data" => %{
+                 type: "map",
+                 required: true,
+                 description: "User data for matching (email, phone, etc.)"
+               },
+               "conversion.optional_fields" => %{
+                 type: "map",
+                 required: false,
+                 description: "Optional fields like event_id, event_source_url"
+               }
+             },
+             example: """
+             card Card do
+               conversion("Purchase", phone: "+1234567890", email: "user@example.com")
+             end
+             """
 
   @impl true
   def validate_config!(%{

--- a/lib/flow_runner/custom_blocks/schedule_flow.ex
+++ b/lib/flow_runner/custom_blocks/schedule_flow.ex
@@ -7,6 +7,41 @@ defmodule FlowRunner.CustomBlocks.ScheduleFlow do
 
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "control"
+  @block_doc type: "Io.Turn.ScheduleFlow",
+             dsl_name: "schedule_stack()",
+             description:
+               "Schedules a journey to run at a future time, or cancels a previously scheduled journey.",
+             config: %{
+               "flow_id" => %{
+                 type: "uuid",
+                 required: true,
+                 description: "UUID of the flow to schedule"
+               },
+               "schedule_at" => %{
+                 type: "datetime",
+                 required: false,
+                 description: "Specific datetime to run the flow"
+               },
+               "schedule_in" => %{
+                 type: "integer",
+                 required: false,
+                 description: "Number of seconds in the future to run the flow"
+               }
+             },
+             example: """
+             card Card do
+               # Schedule to run in 1 hour
+               schedule_stack("10dca9d0-3f0b-11ed-b878-0242ac120002", in: 3600)
+
+               # Or schedule at a specific time
+               schedule_stack("some-uuid", at: datetime_add(now(), 2, "D"))
+             end
+             """,
+             notes:
+               "Either schedule_at or schedule_in must be provided. To cancel, only provide flow_id."
 
   @impl true
   @spec validate_config!(map) :: %{

--- a/lib/flow_runner/custom_blocks/send_content_message.ex
+++ b/lib/flow_runner/custom_blocks/send_content_message.ex
@@ -5,6 +5,32 @@ defmodule FlowRunner.CustomBlocks.SendContentMessage do
 
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "messaging"
+  @block_doc type: "Io.Turn.SendContentMessage",
+             dsl_name: "send_content()",
+             description:
+               "Sends a content card (pre-defined message template) from Turn's content library.",
+             config: %{
+               "content.uuid" => %{
+                 type: "uuid",
+                 required: true,
+                 description: "UUID of the content card to send"
+               },
+               "content.wait_for_input" => %{
+                 type: "boolean | expression",
+                 required: true,
+                 description: "Whether to wait for user input after sending"
+               }
+             },
+             example: """
+             card Card do
+               send_content("content-uuid-here")
+               # Or wait for response:
+               resp = send_content("content-uuid-here", true)
+             end
+             """
   @impl true
   def validate_config!(%{
         "content" =>

--- a/lib/flow_runner/custom_blocks/set_chat_property.ex
+++ b/lib/flow_runner/custom_blocks/set_chat_property.ex
@@ -11,6 +11,24 @@ defmodule FlowRunner.CustomBlocks.SetChatProperty do
   @behaviour FlowRunner.Spec.Block
 
   use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "chat"
+  @block_doc type: "Io.Turn.SetChatProperty",
+             dsl_name: "assign_chat_to()",
+             description: "Assigns the current chat to a user or queue.",
+             config: %{
+               "assign_to" => %{
+                 type: "string",
+                 required: true,
+                 description: "Email of the user to assign the chat to"
+               }
+             },
+             example: """
+             card Card do
+               assign_chat_to("support@example.com")
+             end
+             """
 
   @impl true
   def validate_config!(%{

--- a/lib/flow_runner/custom_blocks/set_message_property.ex
+++ b/lib/flow_runner/custom_blocks/set_message_property.ex
@@ -6,6 +6,30 @@ defmodule FlowRunner.CustomBlocks.SetMessageProperty do
 
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "messaging"
+  @block_doc type: "Io.Turn.SetMessageProperty",
+             dsl_name: "add_label()",
+             description: "Adds a label to a message in the current context.",
+             config: %{
+               "message" => %{
+                 type: "string",
+                 required: true,
+                 description: "The message reference to label"
+               },
+               "labels" => %{
+                 type: "list",
+                 required: true,
+                 description: "List of labels to apply"
+               }
+             },
+             example: """
+             card Card do
+               add_label("important")
+               add_label(operator)
+             end
+             """
 
   @impl true
   def validate_config!(%{

--- a/lib/flow_runner/custom_blocks/update_dictionary.ex
+++ b/lib/flow_runner/custom_blocks/update_dictionary.ex
@@ -5,6 +5,31 @@ defmodule FlowRunner.CustomBlocks.UpdateDictionary do
 
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "data"
+  @block_doc type: "Io.Turn.UpdateDictionary",
+             dsl_name: "update_dictionary()",
+             description: "Updates a key-value pair in a dictionary variable.",
+             config: %{
+               "reference" => %{
+                 type: "string",
+                 required: true,
+                 description: "The dictionary variable to update"
+               },
+               "key" => %{type: "string", required: true, description: "The key to set"},
+               "value" => %{
+                 type: "expression",
+                 required: true,
+                 description: "The value expression to evaluate and store"
+               }
+             },
+             example: """
+             card Deposit do
+               update_dictionary(account, "balance", account.balance + 1)
+               text("You've deposited $1")
+             end
+             """
 
   @impl true
   @spec validate_config!(map) :: %{

--- a/lib/flow_runner/custom_blocks/wait.ex
+++ b/lib/flow_runner/custom_blocks/wait.ex
@@ -21,6 +21,27 @@ defmodule FlowRunner.CustomBlocks.Wait do
   """
 
   @behaviour FlowRunner.Spec.Block
+  use FlowRunner.BlockAutodoc
+
+  @block_category "control"
+  @block_doc type: "Io.Turn.Wait",
+             dsl_name: "wait()",
+             description:
+               "Introduces a delay in the journey flow to control timing between actions.",
+             config: %{
+               "seconds" => %{
+                 type: "integer | expression",
+                 required: true,
+                 description: "Number of seconds to wait (supports expressions)"
+               }
+             },
+             example: """
+             card DelayCard do
+               text("Starting delay...")
+               wait(2)
+               text("Delay completed!")
+             end
+             """
 
   @impl FlowRunner.Spec.Block
   def validate_config!(%{"seconds" => seconds}) when is_integer(seconds) or is_binary(seconds) do

--- a/lib/flow_runner/custom_blocks/webhook.ex
+++ b/lib/flow_runner/custom_blocks/webhook.ex
@@ -21,6 +21,10 @@ defmodule FlowRunner.CustomBlocks.Webhook do
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
   use FlowRunner.BlockAutodoc
+  use Tesla
+
+  require Logger
+  require OpenTelemetry.Tracer, as: Tracer
 
   @block_category "integration"
   @block_doc type: "Io.Turn.Webhook",
@@ -70,9 +74,6 @@ defmodule FlowRunner.CustomBlocks.Webhook do
              end
              """,
              returns: "Map with url, status, body, query, mode, and headers of the response"
-  use Tesla
-  require Logger
-  require OpenTelemetry.Tracer, as: Tracer
 
   @default_timeout :timer.seconds(5)
   @maximum_timeout :timer.seconds(20)

--- a/lib/flow_runner/custom_blocks/webhook.ex
+++ b/lib/flow_runner/custom_blocks/webhook.ex
@@ -20,6 +20,56 @@ defmodule FlowRunner.CustomBlocks.Webhook do
   """
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "integration"
+  @block_doc type: "Io.Turn.Webhook",
+             dsl_name: "get() / post() / put() / patch() / delete()",
+             description:
+               "Makes HTTP requests to external APIs. Supports GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS, and TRACE methods.",
+             config: %{
+               "url" => %{type: "string", required: true, description: "The URL to call"},
+               "method" => %{
+                 type: "string",
+                 required: true,
+                 description: "HTTP method (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS, TRACE)"
+               },
+               "headers" => %{
+                 type: "list",
+                 required: true,
+                 description: "List of [key, value] header pairs"
+               },
+               "query" => %{
+                 type: "list",
+                 required: false,
+                 description: "List of [key, value] query parameter pairs"
+               },
+               "body" => %{
+                 type: "string | list",
+                 required: false,
+                 description: "Request body (string or key-value pairs)"
+               },
+               "timeout" => %{
+                 type: "number",
+                 required: true,
+                 description: "Request timeout in milliseconds (max 20000)"
+               },
+               "mode" => %{
+                 type: "string",
+                 required: true,
+                 description: "\"sync\" or \"async\" execution mode"
+               }
+             },
+             example: """
+             card MyCard do
+               response = get("https://api.example.org/data",
+                 timeout: 5000,
+                 query: [["id", "@contact.id"]]
+               )
+               text("Status: @response.status")
+             end
+             """,
+             returns: "Map with url, status, body, query, mode, and headers of the response"
   use Tesla
   require Logger
   require OpenTelemetry.Tracer, as: Tracer

--- a/lib/flow_runner/custom_blocks/whatsapp_catalog.ex
+++ b/lib/flow_runner/custom_blocks/whatsapp_catalog.ex
@@ -13,6 +13,33 @@ defmodule FlowRunner.CustomBlocks.WhatsAppCatalog do
 
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "whatsapp"
+  @block_doc type: "Io.Turn.WhatsAppCatalog",
+             dsl_name: "catalog()",
+             description:
+               "Displays a WhatsApp product catalog allowing users to browse and order products.",
+             config: %{
+               "catalog.text" => %{
+                 type: "string",
+                 required: true,
+                 description: "The catalog body text"
+               },
+               "catalog.footer" => %{
+                 type: "string",
+                 required: false,
+                 description: "Optional footer text"
+               }
+             },
+             example: """
+             card Card do
+               catalog("Check out our products!") do
+                 footer("Visit our store")
+               end
+             end
+             """,
+             returns: "The user's order/selection from the catalog"
 
   @impl true
   def validate_config!(%{

--- a/lib/flow_runner/custom_blocks/whatsapp_request_location.ex
+++ b/lib/flow_runner/custom_blocks/whatsapp_request_location.ex
@@ -12,6 +12,30 @@ defmodule FlowRunner.CustomBlocks.WhatsAppRequestLocation do
 
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "whatsapp"
+  @block_doc type: "Io.Turn.WhatsAppRequestLocation",
+             dsl_name: "request_location()",
+             description:
+               "Requests the user's location via WhatsApp's native location sharing feature.",
+             config: %{
+               "request_location.text" => %{
+                 type: "string",
+                 required: true,
+                 description: "The message text prompting the user to share their location"
+               }
+             },
+             example: """
+             card RequestLocation do
+               location = request_location("Please share your location")
+             end
+
+             card ThankYou, when: "@input.location != nil" do
+               text("Thank you for sharing your location!")
+             end
+             """,
+             returns: "The user's shared location data"
 
   @impl true
   def validate_config!(%{

--- a/lib/flow_runner/custom_blocks/whatsapp_send_flow.ex
+++ b/lib/flow_runner/custom_blocks/whatsapp_send_flow.ex
@@ -14,6 +14,49 @@ defmodule FlowRunner.CustomBlocks.WhatsAppSendFlow do
 
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "whatsapp"
+  @block_doc type: "Io.Turn.WhatsAppSendFlow",
+             dsl_name: "whatsapp_flow()",
+             description:
+               "Sends a WhatsApp Flow (interactive form) for native data collection on WhatsApp.",
+             config: %{
+               "flow.id" => %{type: "string", required: true, description: "The WhatsApp Flow ID"},
+               "flow.cta" => %{
+                 type: "string",
+                 required: true,
+                 description: "Call-to-action button text"
+               },
+               "flow.screen" => %{
+                 type: "string",
+                 required: true,
+                 description: "The screen to display"
+               },
+               "flow.text" => %{
+                 type: "string",
+                 required: true,
+                 description: "Message body text"
+               },
+               "flow.header" => %{
+                 type: "string",
+                 required: false,
+                 description: "Optional header text"
+               },
+               "flow.footer" => %{
+                 type: "string",
+                 required: false,
+                 description: "Optional footer text"
+               }
+             },
+             example: """
+             card Card do
+               whatsapp_flow("Start Survey", "flow-id", "WELCOME") do
+                 text("Please complete our survey")
+               end
+             end
+             """,
+             returns: "JSON data captured by the WhatsApp Flow"
 
   @impl true
   def validate_config!(%{

--- a/lib/flow_runner/custom_blocks/whatsapp_template_message.ex
+++ b/lib/flow_runner/custom_blocks/whatsapp_template_message.ex
@@ -5,6 +5,35 @@ defmodule FlowRunner.CustomBlocks.WhatsAppTemplateMessage do
 
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "whatsapp"
+  @block_doc type: "Io.Turn.WhatsAppTemplateMessage",
+             dsl_name: "send_message_template()",
+             description: "Sends a WhatsApp message template with dynamic parameters.",
+             config: %{
+               "template.name" => %{
+                 type: "string",
+                 required: true,
+                 description: "The name of the template"
+               },
+               "template.language.code" => %{
+                 type: "string",
+                 required: true,
+                 description: "Language code for the template"
+               },
+               "template.components" => %{
+                 type: "list",
+                 required: true,
+                 description: "List of template components with parameters"
+               }
+             },
+             example: """
+             card Card do
+               send_message_template("template_name", "en", ["param-1", "param-2"])
+             end
+             """,
+             returns: "Map with __value__ and index when template has reply buttons"
   @impl FlowRunner.Spec.Block
   def validate_config!(%{
         "template" =>

--- a/lib/flow_runner/spec/blocks/case.ex
+++ b/lib/flow_runner/spec/blocks/case.ex
@@ -1,9 +1,13 @@
 defmodule FlowRunner.Spec.Blocks.Case do
   @moduledoc """
   Switch between various exit conditions.
+
+  This is an internal block used for routing logic. Users don't call it directly
+  in the DSL - it's generated from `when` conditions and `then` statements.
   """
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+
   alias FlowRunner.Context
   alias FlowRunner.Spec.Block
   alias FlowRunner.Spec.Container

--- a/lib/flow_runner/spec/blocks/log.ex
+++ b/lib/flow_runner/spec/blocks/log.ex
@@ -6,6 +6,14 @@ defmodule FlowRunner.Spec.Blocks.Log do
   use OpenTelemetryDecorator
   use FlowRunner.BlockAutodoc
 
+  alias FlowRunner.Context
+  alias FlowRunner.Spec.Block
+  alias FlowRunner.Spec.Container
+  alias FlowRunner.Spec.Flow
+  alias FlowRunner.Spec.Resource
+
+  require Logger
+
   @block_category "control"
   @block_doc type: "Core.Log",
              dsl_name: "log()",
@@ -23,13 +31,6 @@ defmodule FlowRunner.Spec.Blocks.Log do
                log("hello @today()")
              end
              """
-  alias FlowRunner.Context
-  alias FlowRunner.Spec.Block
-  alias FlowRunner.Spec.Container
-  alias FlowRunner.Spec.Flow
-  alias FlowRunner.Spec.Resource
-
-  require Logger
 
   @impl true
   def validate_config!(%{"message" => message}) do

--- a/lib/flow_runner/spec/blocks/log.ex
+++ b/lib/flow_runner/spec/blocks/log.ex
@@ -4,6 +4,25 @@ defmodule FlowRunner.Spec.Blocks.Log do
   """
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "control"
+  @block_doc type: "Core.Log",
+             dsl_name: "log()",
+             description: "Logs a message to the system log for debugging purposes.",
+             config: %{
+               "message" => %{
+                 type: "string",
+                 required: true,
+                 description: "The message to log"
+               }
+             },
+             example: """
+             card Card do
+               log("user not opted in for follow ups")
+               log("hello @today()")
+             end
+             """
   alias FlowRunner.Context
   alias FlowRunner.Spec.Block
   alias FlowRunner.Spec.Container

--- a/lib/flow_runner/spec/blocks/message.ex
+++ b/lib/flow_runner/spec/blocks/message.ex
@@ -4,6 +4,25 @@ defmodule FlowRunner.Spec.Blocks.Message do
   """
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "messaging"
+  @block_doc type: "MobilePrimitives.Message",
+             dsl_name: "text()",
+             description: "Sends a text message to the user.",
+             config: %{
+               "prompt" => %{
+                 type: "string",
+                 required: true,
+                 description: "The message content to send"
+               }
+             },
+             example: """
+             card Greetings do
+               text("Hello @contact.name!")
+               text("Welcome to our service.")
+             end
+             """
   alias FlowRunner.Context
   alias FlowRunner.Spec.Block
   alias FlowRunner.Spec.Flow

--- a/lib/flow_runner/spec/blocks/message.ex
+++ b/lib/flow_runner/spec/blocks/message.ex
@@ -6,6 +6,10 @@ defmodule FlowRunner.Spec.Blocks.Message do
   use OpenTelemetryDecorator
   use FlowRunner.BlockAutodoc
 
+  alias FlowRunner.Context
+  alias FlowRunner.Spec.Block
+  alias FlowRunner.Spec.Flow
+
   @block_category "messaging"
   @block_doc type: "MobilePrimitives.Message",
              dsl_name: "text()",
@@ -23,9 +27,6 @@ defmodule FlowRunner.Spec.Blocks.Message do
                text("Welcome to our service.")
              end
              """
-  alias FlowRunner.Context
-  alias FlowRunner.Spec.Block
-  alias FlowRunner.Spec.Flow
 
   @impl true
   def validate_config!(%{"prompt" => prompt}) do

--- a/lib/flow_runner/spec/blocks/numeric_response.ex
+++ b/lib/flow_runner/spec/blocks/numeric_response.ex
@@ -1,9 +1,13 @@
 defmodule FlowRunner.Spec.Blocks.NumericResponse do
   @moduledoc """
   A specialisation of a block that allows users to send numeric input.
+
+  This is a FLOIP spec block. In Turn's DSL, numeric input is typically handled
+  via `ask()` with validation expressions.
   """
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+
   alias FlowRunner.Context
   alias FlowRunner.Spec.Block
   alias FlowRunner.Spec.Container

--- a/lib/flow_runner/spec/blocks/open_response.ex
+++ b/lib/flow_runner/spec/blocks/open_response.ex
@@ -7,6 +7,11 @@ defmodule FlowRunner.Spec.Blocks.OpenResponse do
   use OpenTelemetryDecorator
   use FlowRunner.BlockAutodoc
 
+  alias FlowRunner.Context
+  alias FlowRunner.Spec.Block
+  alias FlowRunner.Spec.Container
+  alias FlowRunner.Spec.Flow
+
   @block_category "input"
   @block_doc type: "MobilePrimitives.OpenResponse",
              dsl_name: "ask()",
@@ -34,10 +39,6 @@ defmodule FlowRunner.Spec.Blocks.OpenResponse do
              end
              """,
              returns: "The text response entered by the user"
-  alias FlowRunner.Context
-  alias FlowRunner.Spec.Block
-  alias FlowRunner.Spec.Container
-  alias FlowRunner.Spec.Flow
 
   @impl true
   def validate_config!(%{"prompt" => prompt} = config) do

--- a/lib/flow_runner/spec/blocks/open_response.ex
+++ b/lib/flow_runner/spec/blocks/open_response.ex
@@ -5,6 +5,35 @@ defmodule FlowRunner.Spec.Blocks.OpenResponse do
   """
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "input"
+  @block_doc type: "MobilePrimitives.OpenResponse",
+             dsl_name: "ask()",
+             description:
+               "Asks the user for a free-form text response with optional character limit.",
+             config: %{
+               "prompt" => %{
+                 type: "string",
+                 required: true,
+                 description: "The question to ask the user"
+               },
+               "max_response_characters" => %{
+                 type: "number",
+                 required: false,
+                 description: "Maximum allowed response length"
+               }
+             },
+             example: """
+             card AskName, then: Greetings do
+               name = ask("What's your name?")
+             end
+
+             card Greetings do
+               text("Hello @name!")
+             end
+             """,
+             returns: "The text response entered by the user"
   alias FlowRunner.Context
   alias FlowRunner.Spec.Block
   alias FlowRunner.Spec.Container

--- a/lib/flow_runner/spec/blocks/output.ex
+++ b/lib/flow_runner/spec/blocks/output.ex
@@ -1,9 +1,12 @@
 defmodule FlowRunner.Spec.Blocks.Output do
   @moduledoc """
   Output to a Flow Result which is not yet implemented.
+
+  This is an internal block used for FLOIP spec compliance.
   """
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+
   alias FlowRunner.Context
   alias FlowRunner.Spec.Block
   alias FlowRunner.Spec.Container

--- a/lib/flow_runner/spec/blocks/run_flow.ex
+++ b/lib/flow_runner/spec/blocks/run_flow.ex
@@ -10,6 +10,25 @@ defmodule FlowRunner.Spec.Blocks.RunFlow do
   """
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "control"
+  @block_doc type: "Core.RunFlow",
+             dsl_name: "run_stack()",
+             description:
+               "Runs another journey (stack) and returns to the current flow when complete.",
+             config: %{
+               "flow_id" => %{
+                 type: "uuid",
+                 required: true,
+                 description: "UUID of the flow to run"
+               }
+             },
+             example: """
+             card Card do
+               run_stack("10dca9d0-3f0b-11ed-b878-0242ac120002")
+             end
+             """
   alias FlowRunner.Spec.Block
   alias FlowRunner.Spec.Container
   alias FlowRunner.Spec.Flow

--- a/lib/flow_runner/spec/blocks/run_flow.ex
+++ b/lib/flow_runner/spec/blocks/run_flow.ex
@@ -12,6 +12,10 @@ defmodule FlowRunner.Spec.Blocks.RunFlow do
   use OpenTelemetryDecorator
   use FlowRunner.BlockAutodoc
 
+  alias FlowRunner.Spec.Block
+  alias FlowRunner.Spec.Container
+  alias FlowRunner.Spec.Flow
+
   @block_category "control"
   @block_doc type: "Core.RunFlow",
              dsl_name: "run_stack()",
@@ -29,9 +33,6 @@ defmodule FlowRunner.Spec.Blocks.RunFlow do
                run_stack("10dca9d0-3f0b-11ed-b878-0242ac120002")
              end
              """
-  alias FlowRunner.Spec.Block
-  alias FlowRunner.Spec.Container
-  alias FlowRunner.Spec.Flow
 
   @impl true
   def validate_config!(%{"flow_id" => flow_id}) do

--- a/lib/flow_runner/spec/blocks/select_one_response.ex
+++ b/lib/flow_runner/spec/blocks/select_one_response.ex
@@ -7,6 +7,11 @@ defmodule FlowRunner.Spec.Blocks.SelectOneResponse do
   use OpenTelemetryDecorator
   use FlowRunner.BlockAutodoc
 
+  alias FlowRunner.Context
+  alias FlowRunner.Spec.Block
+  alias FlowRunner.Spec.Container
+  alias FlowRunner.Spec.Flow
+
   @block_category "input"
   @block_doc type: "MobilePrimitives.SelectOneResponse",
              dsl_name: "buttons()",
@@ -37,10 +42,6 @@ defmodule FlowRunner.Spec.Blocks.SelectOneResponse do
              end
              """,
              returns: "Map with __value__, name, index, and label of the selected choice"
-  alias FlowRunner.Context
-  alias FlowRunner.Spec.Block
-  alias FlowRunner.Spec.Container
-  alias FlowRunner.Spec.Flow
 
   @impl true
   def validate_config!(%{"prompt" => prompt, "choices" => choices}) when is_map(choices) do

--- a/lib/flow_runner/spec/blocks/select_one_response.ex
+++ b/lib/flow_runner/spec/blocks/select_one_response.ex
@@ -5,6 +5,38 @@ defmodule FlowRunner.Spec.Blocks.SelectOneResponse do
   """
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "input"
+  @block_doc type: "MobilePrimitives.SelectOneResponse",
+             dsl_name: "buttons()",
+             description:
+               "Presents the user with a set of options as buttons and waits for them to select one.",
+             config: %{
+               "prompt" => %{
+                 type: "string",
+                 required: true,
+                 description: "The message text displayed with the buttons"
+               },
+               "choices" => %{
+                 type: "list",
+                 required: true,
+                 description: "List of button options (card names or [value, label] pairs)"
+               }
+             },
+             example: """
+             card ReadDocument do
+               buttons([Accept, Decline]) do
+                 text("Please read and accept the terms")
+                 document("https://example.org/terms.pdf")
+               end
+             end
+
+             card Accept do
+               text("Thank you for accepting!")
+             end
+             """,
+             returns: "Map with __value__, name, index, and label of the selected choice"
   alias FlowRunner.Context
   alias FlowRunner.Spec.Block
   alias FlowRunner.Spec.Container

--- a/lib/flow_runner/spec/blocks/set_contact_property.ex
+++ b/lib/flow_runner/spec/blocks/set_contact_property.ex
@@ -6,6 +6,13 @@ defmodule FlowRunner.Spec.Blocks.SetContactProperty do
   use OpenTelemetryDecorator
   use FlowRunner.BlockAutodoc
 
+  alias FlowRunner.Context
+  alias FlowRunner.Spec.Block
+  alias FlowRunner.Spec.Container
+  alias FlowRunner.Spec.Flow
+
+  require Logger
+
   @block_category "contact"
   @block_doc type: "Core.SetContactProperty",
              dsl_name: "update_contact()",
@@ -17,12 +24,6 @@ defmodule FlowRunner.Spec.Blocks.SetContactProperty do
                update_contact(opted_in: true)
              end
              """
-  alias FlowRunner.Context
-  alias FlowRunner.Spec.Block
-  alias FlowRunner.Spec.Container
-  alias FlowRunner.Spec.Flow
-
-  require Logger
 
   @impl true
   def validate_config!(_) do

--- a/lib/flow_runner/spec/blocks/set_contact_property.ex
+++ b/lib/flow_runner/spec/blocks/set_contact_property.ex
@@ -4,6 +4,19 @@ defmodule FlowRunner.Spec.Blocks.SetContactProperty do
   """
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "contact"
+  @block_doc type: "Core.SetContactProperty",
+             dsl_name: "update_contact()",
+             description: "Updates one or more properties on the current contact.",
+             config: %{},
+             example: """
+             card SavePreferences do
+               update_contact(name: "Boaty", surname: "McBoatFace")
+               update_contact(opted_in: true)
+             end
+             """
   alias FlowRunner.Context
   alias FlowRunner.Spec.Block
   alias FlowRunner.Spec.Container

--- a/lib/flow_runner/spec/blocks/set_group_membership.ex
+++ b/lib/flow_runner/spec/blocks/set_group_membership.ex
@@ -1,9 +1,12 @@
 defmodule FlowRunner.Spec.Blocks.SetGroupMembership do
   @moduledoc """
   Set a group membership.
+
+  This is a FLOIP spec block for group membership management.
   """
   @behaviour FlowRunner.Spec.Block
   use OpenTelemetryDecorator
+
   alias FlowRunner.Context
   alias FlowRunner.Spec.Block
   alias FlowRunner.Spec.Container


### PR DESCRIPTION
## Summary

Add `FlowRunner.BlockAutodoc` macro module that enables compile-time documentation collection for FLOIP blocks, mirroring the pattern used by `Expression.Autodoc`.

- Add `FlowRunner.BlockAutodoc` module with `@block_doc` and `@block_category` attributes
- Add `@block_doc` documentation to all user-facing DSL blocks:
  - **Spec blocks:** `log()`, `text()`, `ask()`, `run_stack()`, `buttons()`, `update_contact()`
  - **Custom blocks:** `wait()`, `get()/post()/etc`, `schedule_stack()`, `send_message_template()`, `request_location()`, `catalog()`, `whatsapp_flow()`, `conversion()`, `send_content()`, `assign_chat_to()`, `add_label()`, `update_dictionary()`
- Add clarifying moduledocs to internal blocks (`case`, `output`, `numeric_response`, `set_group_membership`) explaining they are not exposed in DSL

This enables Turn to collect block documentation from flow_runner and generate unified documentation for all journey DSL functions.

## Test plan

- [x] `mix compile` succeeds
- [ ] After release, verify Turn can collect docs from flow_runner blocks