### PR TITLE
Add preserve_vars: true opt to evaluate_outgoing return

### DIFF
--- a/lib/flow_runner/spec/block.ex
+++ b/lib/flow_runner/spec/block.ex
@@ -36,14 +36,28 @@ defmodule FlowRunner.Spec.Block do
   On leaving a block give the block an opportunity to evaluate the inputs received.
   This allows the block to fulfill tasks such as validation.
 
-  If the block returns an `{:ok, user_input}` tuple, use the validated input for
-  further processing and inclusion in the context vars for next blocks.
+  Return one of:
 
-  If the block returns and `{:invalid, reason}` tuple the flow runner will exit through
-  the default response.
+    * `{:ok, user_input}` — default. The validated input is stored in
+      `context.vars[block.name]` (and `context.vars["block"]["value"]`) and
+      `waiting_for_user_input` is cleared. Appropriate for
+      question-shaped blocks whose output _is_ the user's reply.
+
+    * `{:ok, user_input, opts}` — same as above plus a keyword list of
+      options. Supported options:
+
+        - `preserve_vars: true` — do NOT overwrite `context.vars[block.name]`
+          with the user input, but still clear `waiting_for_user_input`.
+          Use this for blocks that set their own structured vars before
+          pausing and must preserve that structure across the resume so
+          downstream exits can read it.
+
+    * `{:invalid, reason}` — the flow runner will exit through the
+      block's default response.
   """
   @callback evaluate_outgoing(Container.t(), Flow.t(), Block.t(), Context.t(), user_input :: any) ::
               {:ok, user_input :: any}
+              | {:ok, user_input :: any, opts :: Keyword.t()}
               | {:invalid, reason :: String.t()}
 
   @derive Jason.Encoder
@@ -133,23 +147,33 @@ defmodule FlowRunner.Spec.Block do
   end
 
   @spec evaluate_user_input(Block.t(), Context.t(), iodata()) ::
-          {:ok, Context.t()}
-  def evaluate_user_input(_block, context, nil) when context.waiting_for_user_input == true do
+          {:ok, Context.t()} | {:error, String.t()}
+  def evaluate_user_input(block, context, user_input),
+    do: evaluate_user_input(block, context, user_input, [])
+
+  @spec evaluate_user_input(Block.t(), Context.t(), iodata(), Keyword.t()) ::
+          {:ok, Context.t()} | {:error, String.t()}
+  def evaluate_user_input(_block, context, nil, _opts)
+      when context.waiting_for_user_input == true do
     {:ok, context}
   end
 
-  def evaluate_user_input(block, %Context{} = context, user_input)
-      when context.waiting_for_user_input == true do
-    vars =
-      Map.merge(context.vars, %{
-        "block" => %{"value" => user_input},
-        block.name => user_input
-      })
+  def evaluate_user_input(block, %Context{} = context, user_input, opts)
+      when context.waiting_for_user_input == true and is_list(opts) do
+    if Keyword.get(opts, :preserve_vars, false) do
+      {:ok, %Context{context | waiting_for_user_input: false}}
+    else
+      vars =
+        Map.merge(context.vars, %{
+          "block" => %{"value" => user_input},
+          block.name => user_input
+        })
 
-    {:ok, %Context{context | vars: vars, waiting_for_user_input: false}}
+      {:ok, %Context{context | vars: vars, waiting_for_user_input: false}}
+    end
   end
 
-  def evaluate_user_input(%{type: "Core.Case"} = block, %Context{} = context, user_input) do
+  def evaluate_user_input(%{type: "Core.Case"} = block, %Context{} = context, user_input, _opts) do
     vars =
       Map.merge(context.vars, %{
         "block" => %{"value" => user_input},
@@ -159,11 +183,11 @@ defmodule FlowRunner.Spec.Block do
     {:ok, %Context{context | vars: vars}}
   end
 
-  def evaluate_user_input(_block, context, nil) do
+  def evaluate_user_input(_block, context, nil, _opts) do
     {:ok, context}
   end
 
-  def evaluate_user_input(_block, _context, user_input) do
+  def evaluate_user_input(_block, _context, user_input, _opts) do
     {:error, "unexpectedly received user input: #{inspect(user_input)}"}
   end
 
@@ -212,10 +236,12 @@ defmodule FlowRunner.Spec.Block do
 
     block_module = get_block(FlowRunner.blocks_module(), type)
 
-    with {:ok, user_input} <-
-           block_module.evaluate_outgoing(container, flow, block, context, user_input),
+    with {:ok, user_input, opts} <-
+           normalize_outgoing(
+             block_module.evaluate_outgoing(container, flow, block, context, user_input)
+           ),
          # Process any user input we have been given.
-         {:ok, context} <- evaluate_user_input(block, context, user_input),
+         {:ok, context} <- evaluate_user_input(block, context, user_input, opts),
          {:ok, context, block} <- fetch_next_block(block, flow, context) do
       {:ok, context, block}
     else
@@ -227,6 +253,10 @@ defmodule FlowRunner.Spec.Block do
         fetch_default_block(block, flow, context)
     end
   end
+
+  defp normalize_outgoing({:ok, user_input}), do: {:ok, user_input, []}
+  defp normalize_outgoing({:ok, user_input, opts}) when is_list(opts), do: {:ok, user_input, opts}
+  defp normalize_outgoing({:invalid, _} = invalid), do: invalid
 
   @spec fetch_default_block(Block.t(), Flow.t(), Context.t()) ::
           {:error, String.t()} | {:ok, Context.t(), Block.t() | nil}

--- a/test/block_test.exs
+++ b/test/block_test.exs
@@ -24,6 +24,64 @@ defmodule BlockTest do
            } == context
   end
 
+  describe "evaluate_user_input/4 with preserve_vars: true" do
+    test "clears waiting_for_user_input without overwriting vars[block.name]" do
+      block = %Block{name: "structured_block"}
+
+      existing_vars = %{
+        "structured_block" => %{"status" => "done", "payload" => "foo"},
+        "other" => "untouched"
+      }
+
+      context = %Context{waiting_for_user_input: true, vars: existing_vars}
+
+      assert {:ok, updated} =
+               Block.evaluate_user_input(block, context, "hello", preserve_vars: true)
+
+      assert updated.waiting_for_user_input == false
+      # Vars are NOT overwritten by the raw user input
+      assert updated.vars == existing_vars
+    end
+
+    test "nil user_input with preserve_vars: true still returns context unchanged" do
+      block = %Block{name: "structured_block"}
+
+      context = %Context{
+        waiting_for_user_input: true,
+        vars: %{"structured_block" => %{"k" => "v"}}
+      }
+
+      # nil short-circuits the first clause before opts are considered
+      assert {:ok, ^context} = Block.evaluate_user_input(block, context, nil, preserve_vars: true)
+    end
+
+    test "preserve_vars: false falls back to the default overwrite behavior" do
+      block = %Block{name: "customers_age"}
+      context = %Context{waiting_for_user_input: true}
+
+      assert {:ok, updated} =
+               Block.evaluate_user_input(block, context, "20", preserve_vars: false)
+
+      assert %Context{
+               vars: %{
+                 "block" => %{"value" => "20"},
+                 "customers_age" => "20"
+               },
+               waiting_for_user_input: false
+             } == updated
+    end
+
+    test "empty opts list is equivalent to the 3-arity call" do
+      block = %Block{name: "customers_age"}
+      context = %Context{waiting_for_user_input: true}
+
+      {:ok, with_opts} = Block.evaluate_user_input(block, context, "20", [])
+      {:ok, without_opts} = Block.evaluate_user_input(block, context, "20")
+
+      assert with_opts == without_opts
+    end
+  end
+
   test "evaluate exits" do
     context = %Context{
       vars: %{"block" => %{"value" => 10}}


### PR DESCRIPTION
## Summary

Extends the `evaluate_outgoing/5` callback contract with an optional third element: `{:ok, user_input, opts}`. The only currently-supported option is `preserve_vars: true`, which causes flow_runner to clear `waiting_for_user_input` on resume **without** overwriting `context.vars[block.name]` with the raw user input.

## Why

Today, when a block is paused waiting for user input and then resumes, flow_runner always overwrites `context.vars[block.name]` with whatever raw string the user typed (see `evaluate_user_input/3`). This is the right behavior for question-shaped blocks like `ask()` whose var _is_ the user's reply.

It is wrong for blocks that set structured vars before pausing and depend on those vars surviving the resume intact so downstream exits can read them. On resume the structured map gets clobbered by the raw user input and routing breaks.

Without this change, such a block has to either lose its structured vars on resume or work around it with a sentinel return value plus manual out-of-band clearing of `waiting_for_user_input` — which is brittle (ties semantics to a sentinel) and leaks the concern into every consumer of flow_runner.

## What changes

### Callback contract (`lib/flow_runner/spec/block.ex`)

`@callback evaluate_outgoing` now permits three return shapes:

- `{:ok, user_input}` — unchanged. Overwrites vars and clears flag.
- `{:ok, user_input, opts}` — **new**. Honors `preserve_vars: true` to skip the var overwrite while still clearing the flag.
- `{:invalid, reason}` — unchanged.

### `evaluate_user_input` (`lib/flow_runner/spec/block.ex`)

- New 4-arity version that accepts a keyword list of opts.
- 3-arity version preserved as a delegation to `evaluate_user_input/4` with `opts: []`, so all existing callers are unaffected.
- `preserve_vars: true` branch clears `waiting_for_user_input` without touching `context.vars`.

### `evaluate_outgoing/5` dispatch

Normalizes the block's return shape into `{:ok, user_input, opts}` internally via a private `normalize_outgoing/1` helper, then threads `opts` into the 4-arity `evaluate_user_input`. The existing 2-tuple shape continues to work transparently.

## Backwards compatibility

- All existing `evaluate_outgoing/5` implementations in this repo still return `{:ok, user_input}` — untouched, no migration needed.
- `evaluate_user_input/3` is still public and delegates to `/4`.
- 145 existing tests continue to pass.

## Test plan

- [x] `mix test` — 145 tests, 0 failures
- [x] `mix format --check-formatted` — clean
- [x] `mix credo --strict` — no issues
- [x] Added 4 new tests in `test/block_test.exs` covering:
  - `preserve_vars: true` clears flag without overwriting vars
  - `preserve_vars: true` + `nil` user_input is a no-op (same as today)
  - `preserve_vars: false` behaves identically to the default overwrite
  - 3-arity and 4-arity-with-empty-opts produce the same result