### PR TITLE
[ci] Pin CLA assistant action to commit SHA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Beta Release
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret


### PR DESCRIPTION
## Summary
- Pin `contributor-assistant/github-action` to full commit SHA (`ca4a40a7d1004f18d9960b404b97e5f30a505a08`) to comply with org policy requiring all actions to be pinned

This is split out from #312 because the CLA workflow uses `pull_request_target`, which runs from the **base branch** (develop), not the PR branch. Until this is merged to develop, the CLA check will fail on all PRs.

## Test plan
- [ ] CLA check passes on subsequent PRs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)