### PR TITLE
Add WhatsApp call permission request block

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ by adding `flow_runner` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:flow_runner, "~> 6.9.0"}
+    {:flow_runner, "~> 6.10.0"}
   ]
 end
 ```

--- a/lib/flow_runner/blocks.ex
+++ b/lib/flow_runner/blocks.ex
@@ -28,6 +28,8 @@ defmodule FlowRunner.Blocks do
       "Io.Turn.SetChatProperty" => FlowRunner.CustomBlocks.SetChatProperty,
       "Io.Turn.SetMessageProperty" => FlowRunner.CustomBlocks.SetMessageProperty,
       "Io.Turn.UpdateDictionary" => FlowRunner.CustomBlocks.UpdateDictionary,
+      "Io.Turn.WhatsAppCallPermissionRequest" =>
+        FlowRunner.CustomBlocks.WhatsAppCallPermissionRequest,
       "Io.Turn.WhatsAppCatalog" => FlowRunner.CustomBlocks.WhatsAppCatalog,
       "Io.Turn.WhatsAppRequestLocation" => FlowRunner.CustomBlocks.WhatsAppRequestLocation,
       "Io.Turn.WhatsAppSendFlow" => FlowRunner.CustomBlocks.WhatsAppSendFlow,

--- a/lib/flow_runner/custom_blocks/whatsapp_call_permission_request.ex
+++ b/lib/flow_runner/custom_blocks/whatsapp_call_permission_request.ex
@@ -1,0 +1,61 @@
+defmodule FlowRunner.CustomBlocks.WhatsAppCallPermissionRequest do
+  @moduledoc """
+  A block to handle WhatsApp call permission request messages.
+
+  WhatsApp call permission request messages allow businesses to ask
+  the user for permission to call them. This block handles the display
+  of the permission request with a text message and a permission button.
+
+  The `call_permission_request` block compiles to this FLOIP block.
+  The `text` config parameter is required for the request message.
+  """
+
+  @behaviour FlowRunner.Spec.Block
+  use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "whatsapp"
+  @block_doc type: "Io.Turn.WhatsAppCallPermissionRequest",
+             dsl_name: "call_permission_request()",
+             description:
+               "Requests permission to call the user via WhatsApp's native call permission feature.",
+             config: %{
+               "call_permission_request.text" => %{
+                 type: "string",
+                 required: true,
+                 description: "The message text prompting the user to grant call permission"
+               }
+             },
+             example: """
+             card RequestPermission do
+               granted = call_permission_request("Can we call you to assist?")
+             end
+
+             card ThankYou do
+               text("Thank you!")
+             end
+             """,
+             returns: "The user's call permission response"
+
+  @impl true
+  def validate_config!(%{"call_permission_request" => %{"text" => text}}) do
+    %{call_permission_request: %{text: text}}
+  end
+
+  @impl true
+  def evaluate_incoming(container, flow, block, context) do
+    context = %{
+      context
+      | last_block_uuid: block.uuid,
+        # call permission request messages wait for user input (permission reply)
+        waiting_for_user_input: true
+    }
+
+    {:ok, container, flow, block, context}
+  end
+
+  @impl true
+  def evaluate_outgoing(_container, _flow, _block, _context, user_input) do
+    {:ok, user_input}
+  end
+end

--- a/lib/flow_runner/simulator.ex
+++ b/lib/flow_runner/simulator.ex
@@ -633,6 +633,44 @@ defmodule FlowRunner.Simulator do
     {{:interactive, outputs}, sim}
   end
 
+  def output_block(sim, %{type: "Io.Turn.WhatsAppCallPermissionRequest", config: config}) do
+    call_permission_config = config.call_permission_request
+
+    # Resolve the call permission request text resource and evaluate it
+    text_resource = fetch_resource_by_uuid!(sim, call_permission_config.text)
+    [text_resource_value] = fetch_resource_values(sim, text_resource, "TEXT")
+    request_text = resource_value_output(sim, text_resource_value).value
+
+    # Create message output
+    # NOTE: This is a warning since the call permission message type isn't fully supported in the simulator
+    text_output =
+      "[WARNING]\nThis message type isn't fully supported by the simulator, try previewing this on your phone.\n\n#{request_text}"
+
+    # Create the main text output
+    text_output = %Output{
+      mime_type: "text/plain",
+      raw_value: text_output,
+      value: text_output,
+      content_type: "TEXT"
+    }
+
+    # Create the "Choose preference" button
+    button_output = %Output{
+      mime_type: "text/plain",
+      raw_value: "Choose preference",
+      value: "Choose preference",
+      event_value: "call_permission_request",
+      content_type: "TEXT"
+    }
+
+    outputs = [
+      text: [text_output],
+      button: [button_output]
+    ]
+
+    {{:interactive, outputs}, sim}
+  end
+
   def output_block(sim, %{type: "Core.Log", config: %{message: text_resource_uuid}}) do
     log_resource = fetch_resource_by_uuid!(sim, text_resource_uuid)
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule FlowRunner.MixProject do
   use Mix.Project
 
-  @version "6.9.0"
+  @version "6.10.0"
 
   def project do
     [

--- a/priv/fixtures/test/simulator/whatsapp_call_permission_request_basic.flow
+++ b/priv/fixtures/test/simulator/whatsapp_call_permission_request_basic.flow
@@ -1,0 +1,97 @@
+{
+  "name": "WhatsApp Call Permission Request Basic Test",
+  "description": "Basic WhatsApp call permission request message test",
+  "resources": [
+    {
+      "values": [
+        {
+          "value": "End of flow",
+          "modes": [
+            "RICH_MESSAGING"
+          ],
+          "content_type": "TEXT",
+          "mime_type": "text/plain",
+          "language_id": "279d802b-479a-4a15-9a68-cd29c39b8a94"
+        }
+      ],
+      "uuid": "af8bdbce-3b5a-473d-9566-0fbba71256d0"
+    },
+    {
+      "values": [
+        {
+          "value": "Can we call you to assist?",
+          "modes": [
+            "RICH_MESSAGING"
+          ],
+          "content_type": "TEXT",
+          "mime_type": "text/plain",
+          "language_id": "279d802b-479a-4a15-9a68-cd29c39b8a94"
+        }
+      ],
+      "uuid": "abcdef01-1234-5678-9012-123456789abc"
+    }
+  ],
+  "uuid": "e5c4921f-11e4-4a3f-83ce-86c1781e6fb8",
+  "flows": [
+    {
+      "label": null,
+      "name": "stack",
+      "blocks": [
+        {
+          "label": null,
+          "name": "whatsapp_call_permission_request_block",
+          "type": "Io.Turn.WhatsAppCallPermissionRequest",
+          "config": {
+            "call_permission_request": {
+              "text": "abcdef01-1234-5678-9012-123456789abc"
+            }
+          },
+          "tags": [],
+          "uuid": "db761083-a029-622f-9877-5eecb2ec7717",
+          "semantic_label": null,
+          "ui_metadata": {
+            "canvas_location": {
+              "x": 120,
+              "y": 120
+            }
+          },
+          "vendor_metadata": {}
+        },
+        {
+          "label": null,
+          "name": "end",
+          "type": "MobilePrimitives.Message",
+          "config": {
+            "prompt": "af8bdbce-3b5a-473d-9566-0fbba71256d0"
+          },
+          "tags": [],
+          "uuid": "4eca4020-3fd6-4b9e-add8-34bd0b27b7a0",
+          "semantic_label": null,
+          "ui_metadata": {
+            "canvas_location": {
+              "x": 120,
+              "y": 240
+            }
+          },
+          "vendor_metadata": {}
+        }
+      ],
+      "first_block_id": "db761083-a029-622f-9877-5eecb2ec7717",
+      "uuid": "c12c66c8-7bde-5fb5-b849-e4063f4f1cdd",
+      "languages": [
+        {
+          "iso_639_3": "eng",
+          "id": "279d802b-479a-4a15-9a68-cd29c39b8a94",
+          "label": "English"
+        }
+      ],
+      "last_modified": "2023-10-01T00:00:00Z",
+      "interaction_timeout": 60,
+      "name": "WhatsApp Call Permission Request Flow",
+      "supported_modes": [
+        "RICH_MESSAGING"
+      ]
+    }
+  ],
+  "specification_version": "1.0.0-rc2"
+}

--- a/test/flow_runner/custom_blocks/whatsapp_call_permission_request_test.exs
+++ b/test/flow_runner/custom_blocks/whatsapp_call_permission_request_test.exs
@@ -1,0 +1,99 @@
+defmodule FlowRunner.CustomBlocks.WhatsAppCallPermissionRequestTest do
+  use ExUnit.Case, async: true
+
+  alias FlowRunner.CustomBlocks.WhatsAppCallPermissionRequest
+
+  describe "validate_config!/1" do
+    test "returns call_permission_request config with required text parameter" do
+      config = %{
+        "call_permission_request" => %{
+          "text" => "Can we call you to assist?"
+        }
+      }
+
+      result = WhatsAppCallPermissionRequest.validate_config!(config)
+
+      assert result.call_permission_request.text == "Can we call you to assist?"
+    end
+
+    test "raises error when call_permission_request key is missing" do
+      config = %{}
+
+      assert_raise FunctionClauseError, fn ->
+        WhatsAppCallPermissionRequest.validate_config!(config)
+      end
+    end
+
+    test "raises error when text parameter is missing" do
+      config = %{
+        "call_permission_request" => %{}
+      }
+
+      assert_raise FunctionClauseError, fn ->
+        WhatsAppCallPermissionRequest.validate_config!(config)
+      end
+    end
+  end
+
+  describe "evaluate_incoming/4" do
+    test "sets waiting_for_user_input to true and updates last_block_uuid" do
+      container = %{}
+      flow = %{}
+      block = %{uuid: "test-block-uuid"}
+
+      context = %{
+        last_block_uuid: "previous-uuid",
+        waiting_for_user_input: false
+      }
+
+      {:ok, returned_container, returned_flow, returned_block, returned_context} =
+        WhatsAppCallPermissionRequest.evaluate_incoming(container, flow, block, context)
+
+      assert returned_container == container
+      assert returned_flow == flow
+      assert returned_block == block
+      assert returned_context.last_block_uuid == "test-block-uuid"
+      assert returned_context.waiting_for_user_input == true
+    end
+  end
+
+  describe "evaluate_outgoing/5" do
+    test "returns user input unchanged" do
+      container = %{}
+      flow = %{}
+      block = %{}
+      context = %{}
+      user_input = %{type: "interactive", call_permission_reply: %{"response" => "accept"}}
+
+      {:ok, returned_input} =
+        WhatsAppCallPermissionRequest.evaluate_outgoing(
+          container,
+          flow,
+          block,
+          context,
+          user_input
+        )
+
+      assert returned_input == user_input
+    end
+
+    test "returns user input unchanged for different input types" do
+      container = %{}
+      flow = %{}
+      block = %{}
+      context = %{}
+
+      test_inputs = [
+        %{type: "interactive", call_permission_reply: %{"response" => "accept"}},
+        %{type: "interactive", call_permission_reply: %{"response" => "reject"}}
+      ]
+
+      for input <- test_inputs do
+        {:ok, returned_input} =
+          WhatsAppCallPermissionRequest.evaluate_outgoing(container, flow, block, context, input)
+
+        assert returned_input == input
+      end
+    end
+  end
+end

--- a/test/flow_runner/simulator_test.exs
+++ b/test/flow_runner/simulator_test.exs
@@ -124,6 +124,21 @@ defmodule FlowRunner.SimulatorTest do
            |> has_value("Send location")
   end
 
+  test "simulator with whatsapp call permission request" do
+    sim = Simulator.new(read_floip!("whatsapp_call_permission_request_basic"))
+    {:waiting, _sim, outputs} = Simulator.start(sim)
+
+    assert outputs
+           |> get_in([:interactive, :text])
+           |> with_content_type("TEXT")
+           |> has_value("Can we call you to assist?")
+
+    assert outputs
+           |> get_in([:interactive, :button])
+           |> with_content_type("TEXT")
+           |> has_value("Choose preference")
+  end
+
   test "simulator with quick reply" do
     sim = Simulator.new(read_floip!("quick_reply_stack"))
 


### PR DESCRIPTION
## Summary

Adds the `Io.Turn.WhatsAppCallPermissionRequest` custom block, which requests permission to call the user via WhatsApp's native call permission feature.

- New `FlowRunner.CustomBlocks.WhatsAppCallPermissionRequest` block (`call_permission_request()` DSL), with a required `text` config parameter for the request message. The block waits for user input (the permission reply) on incoming and passes the user input through on outgoing.
- Registers the block in `FlowRunner.Blocks`.
- Adds simulator output support in `FlowRunner.Simulator`, rendering the request text plus a "Choose preference" button. Since this message type isn't fully supported in the simulator, the rendered text is prefixed with a `[WARNING]` advising the user to preview on their phone.
- Adds a fixture flow and tests for the block and simulator behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)