### PR TITLE
Accept array shape on set_contact_property config (FLOIP spec 1.0.0-rc4)

### DIFF
--- a/lib/flow_runner/spec/block.ex
+++ b/lib/flow_runner/spec/block.ex
@@ -125,12 +125,30 @@ defmodule FlowRunner.Spec.Block do
     %{set_contact_property: %{property_key: property_key, property_value: property_value}}
   end
 
+  def load_config_for_set_contact_property!(%{"set_contact_property" => properties})
+      when is_list(properties) do
+    %{set_contact_property: Enum.map(properties, &cast_set_contact_property_entry!/1)}
+  end
+
   def load_config_for_set_contact_property!(%{"set_contact_property" => _}) do
-    raise "set_contact_property! requires 'property_key' and 'property_value' fields."
+    raise "set_contact_property! requires 'property_key' and 'property_value' fields, " <>
+            "or a list of such objects."
   end
 
   def load_config_for_set_contact_property!(%{}) do
     %{}
+  end
+
+  defp cast_set_contact_property_entry!(%{
+         "property_key" => property_key,
+         "property_value" => property_value
+       }) do
+    %{property_key: property_key, property_value: property_value}
+  end
+
+  defp cast_set_contact_property_entry!(other) do
+    raise "set_contact_property! list entry requires 'property_key' and " <>
+            "'property_value' fields, got: #{inspect(other)}"
   end
 
   def load_config_for_type!(blocks_module, type, config) do

--- a/lib/flow_runner/spec/block.ex
+++ b/lib/flow_runner/spec/block.ex
@@ -125,18 +125,13 @@ defmodule FlowRunner.Spec.Block do
     %{set_contact_property: %{property_key: property_key, property_value: property_value}}
   end
 
-  def load_config_for_set_contact_property!(%{"set_contact_property" => properties})
-      when is_list(properties) do
+  def load_config_for_set_contact_property!(%{"set_contact_property" => [_ | _] = properties}) do
     %{set_contact_property: Enum.map(properties, &cast_set_contact_property_entry!/1)}
   end
 
-  def load_config_for_set_contact_property!(%{"set_contact_property" => _}) do
+  def load_config_for_set_contact_property!(_other) do
     raise "set_contact_property! requires 'property_key' and 'property_value' fields, " <>
             "or a list of such objects."
-  end
-
-  def load_config_for_set_contact_property!(%{}) do
-    %{}
   end
 
   defp cast_set_contact_property_entry!(%{
@@ -159,9 +154,15 @@ defmodule FlowRunner.Spec.Block do
         raise "unknown block type '#{type}'"
       end
 
-    # All blocks can optionally have a set_contact_property config. Let's
-    # validate that now and merge it in.
-    Map.merge(validated_config, load_config_for_set_contact_property!(config))
+    # Blocks may optionally carry a `set_contact_property` config (used by
+    # SetContactProperty as the primary payload and as an optional capability
+    # on other blocks). Only validate it when the key is actually present so
+    # blocks without it don't go through the strict shape check.
+    if Map.has_key?(config, "set_contact_property") do
+      Map.merge(validated_config, load_config_for_set_contact_property!(config))
+    else
+      validated_config
+    end
   end
 
   @spec evaluate_user_input(Block.t(), Context.t(), iodata()) ::

--- a/test/block_test.exs
+++ b/test/block_test.exs
@@ -258,4 +258,61 @@ defmodule BlockTest do
     # Should fall through to default exit because valid.__value__ is false
     assert {:ok, %Exit{uuid: "failure-exit"}} = Block.evaluate_exits(block, context_false)
   end
+
+  describe "load_config_for_set_contact_property!/1" do
+    test "accepts the singular shape" do
+      assert %{
+               set_contact_property: %{
+                 property_key: "name",
+                 property_value: "Boaty"
+               }
+             } =
+               Block.load_config_for_set_contact_property!(%{
+                 "set_contact_property" => %{
+                   "property_key" => "name",
+                   "property_value" => "Boaty"
+                 }
+               })
+    end
+
+    test "accepts the array shape (FLOIP spec 1.0.0-rc4)" do
+      assert %{
+               set_contact_property: [
+                 %{property_key: "name", property_value: "Boaty"},
+                 %{property_key: "surname", property_value: "McBoatFace"}
+               ]
+             } =
+               Block.load_config_for_set_contact_property!(%{
+                 "set_contact_property" => [
+                   %{"property_key" => "name", "property_value" => "Boaty"},
+                   %{"property_key" => "surname", "property_value" => "McBoatFace"}
+                 ]
+               })
+    end
+
+    test "accepts an empty array" do
+      assert %{set_contact_property: []} =
+               Block.load_config_for_set_contact_property!(%{"set_contact_property" => []})
+    end
+
+    test "returns an empty config when set_contact_property is absent" do
+      assert %{} == Block.load_config_for_set_contact_property!(%{})
+    end
+
+    test "raises when an array entry is missing property_key" do
+      assert_raise RuntimeError,
+                   ~r/list entry requires 'property_key' and 'property_value'/,
+                   fn ->
+                     Block.load_config_for_set_contact_property!(%{
+                       "set_contact_property" => [%{"property_value" => "Boaty"}]
+                     })
+                   end
+    end
+
+    test "raises when the shape is neither singular map nor array" do
+      assert_raise RuntimeError, ~r/'property_key' and 'property_value' fields/, fn ->
+        Block.load_config_for_set_contact_property!(%{"set_contact_property" => "not-a-shape"})
+      end
+    end
+  end
 end

--- a/test/block_test.exs
+++ b/test/block_test.exs
@@ -290,13 +290,10 @@ defmodule BlockTest do
                })
     end
 
-    test "accepts an empty array" do
-      assert %{set_contact_property: []} =
-               Block.load_config_for_set_contact_property!(%{"set_contact_property" => []})
-    end
-
-    test "returns an empty config when set_contact_property is absent" do
-      assert %{} == Block.load_config_for_set_contact_property!(%{})
+    test "raises on an empty array" do
+      assert_raise RuntimeError, ~r/'property_key' and 'property_value' fields/, fn ->
+        Block.load_config_for_set_contact_property!(%{"set_contact_property" => []})
+      end
     end
 
     test "raises when an array entry is missing property_key" do


### PR DESCRIPTION
## Summary

Extends `Block.load_config_for_set_contact_property!/1` to accept `set_contact_property` as either:

- the existing singular shape: `{ "property_key": ..., "property_value": ... }`, or
- an array of such objects, per [FLOIP spec 1.0.0-rc4 (2022-07-04)](https://github.com/FLOIP/flow-spec/blob/master/CHANGELOG.md):

> "Allow setting an array of multiple contact properties within one block. This simplifies common flows compared to using multiple blocks, and improves interoperability."

Schema (from `FLOIP/flow-spec/layers/1-core.md`):

```json
"set_contact_property": [
  { "property_key": "name",    "property_value": "Boaty" },
  { "property_key": "surname", "property_value": "McBoatFace" }
]
```

The existing singular shape continues to work unchanged, so this is purely additive — no breaking change for in-flight FLOIP containers.