### PR TITLE
Bump default specification_version to 1.0.0-rc4

### DIFF
--- a/lib/flow_runner/blocks.ex
+++ b/lib/flow_runner/blocks.ex
@@ -1,6 +1,6 @@
 defmodule FlowRunner.Blocks do
   @moduledoc """
-  The default blocks as per the FLOIP spec 1.0.0-rc3
+  The default blocks as per the FLOIP spec 1.0.0-rc4
   """
 
   @callback blocks() :: %{(type :: String.t()) => implementation :: module}

--- a/lib/flow_runner/builder.ex
+++ b/lib/flow_runner/builder.ex
@@ -221,7 +221,7 @@ defmodule FlowRunner.FlowBuilder do
           )
 
         %{
-          "specification_version" => "1.0.0-rc3",
+          "specification_version" => "1.0.0-rc4",
           "uuid" => UUID.uuid4(),
           "description" => @description,
           "name" => @name,

--- a/test/builder_test.exs
+++ b/test/builder_test.exs
@@ -9,7 +9,7 @@ defmodule FlowRunner.FlowBuilderTest do
     five_minutes = :timer.minutes(5)
 
     assert %{
-             "specification_version" => "1.0.0-rc3",
+             "specification_version" => "1.0.0-rc4",
              "name" => "My flow",
              "description" => "The description",
              "uuid" => _container_uuid,


### PR DESCRIPTION
Follow-up to #320 (array shape for `set_contact_property`). The default `specification_version` written by the `Floip1` builder was still `1.0.0-rc3`, even though the validation layer now accepts the array shape introduced in 1.0.0-rc4 (https://github.com/FLOIP/flow-spec/blob/master/CHANGELOG.md). This bumps the default so consumers of generated FLOIP can tell which shape to expect.

## Changes
- `lib/flow_runner/builder.ex` — default version string
- `lib/flow_runner/blocks.ex` — module docstring
- `test/builder_test.exs` — assertion updated to match

All 157 tests pass.