### PR TITLE
Add WhatsAppCallToAction custom block

### DIFF
--- a/lib/flow_runner/blocks.ex
+++ b/lib/flow_runner/blocks.ex
@@ -30,6 +30,7 @@ defmodule FlowRunner.Blocks do
       "Io.Turn.UpdateDictionary" => FlowRunner.CustomBlocks.UpdateDictionary,
       "Io.Turn.WhatsAppCallPermissionRequest" =>
         FlowRunner.CustomBlocks.WhatsAppCallPermissionRequest,
+      "Io.Turn.WhatsAppCallToAction" => FlowRunner.CustomBlocks.WhatsAppCallToAction,
       "Io.Turn.WhatsAppCatalog" => FlowRunner.CustomBlocks.WhatsAppCatalog,
       "Io.Turn.WhatsAppRequestLocation" => FlowRunner.CustomBlocks.WhatsAppRequestLocation,
       "Io.Turn.WhatsAppSendFlow" => FlowRunner.CustomBlocks.WhatsAppSendFlow,

--- a/lib/flow_runner/custom_blocks/whatsapp_call_to_action.ex
+++ b/lib/flow_runner/custom_blocks/whatsapp_call_to_action.ex
@@ -1,0 +1,116 @@
+defmodule FlowRunner.CustomBlocks.WhatsAppCallToAction do
+  @moduledoc """
+  A block to handle WhatsApp interactive Call-to-Action (CTA) URL messages.
+
+  CTA URL messages display a tappable button that opens a URL in the
+  user's browser. They are useful when you want to direct users to a
+  website without exposing the raw URL in the message body.
+
+  See https://developers.facebook.com/documentation/business-messaging/whatsapp/messages/interactive-cta-url-messages
+
+  The `whatsapp_cta` block compiles to this FLOIP block.
+  The `url`, `cta`, and `text` config parameters are required.
+
+  The `header` and `footer` are optional.
+  """
+
+  @behaviour FlowRunner.Spec.Block
+  use OpenTelemetryDecorator
+  use FlowRunner.BlockAutodoc
+
+  @block_category "whatsapp"
+  @block_doc type: "Io.Turn.WhatsAppCallToAction",
+             dsl_name: "whatsapp_cta()",
+             description:
+               "Sends a WhatsApp interactive Call-to-Action (CTA) URL message with a tappable button that opens a URL.",
+             config: %{
+               "cta_url.url" => %{
+                 type: "string",
+                 required: true,
+                 description: "The URL the button opens"
+               },
+               "cta_url.cta" => %{
+                 type: "string",
+                 required: true,
+                 description: "Call-to-action button text"
+               },
+               "cta_url.text" => %{
+                 type: "string",
+                 required: true,
+                 description: "Message body text"
+               },
+               "cta_url.header" => %{
+                 type: "string",
+                 required: false,
+                 description: "Optional header text"
+               },
+               "cta_url.footer" => %{
+                 type: "string",
+                 required: false,
+                 description: "Optional footer text"
+               }
+             },
+             example: """
+             card Card do
+               whatsapp_cta("Visit our site", "https://example.com") do
+                 text("Tap the button below to learn more")
+               end
+             end
+             """,
+             returns: "Nothing; CTA URL messages do not wait for user input"
+
+  @impl true
+  def validate_config!(%{
+        "cta_url" =>
+          %{
+            "url" => url,
+            "cta" => cta,
+            "text" => text
+          } = params
+      }) do
+    optional_params = read_optional_params(params, [:header, :footer])
+
+    cta_url_config =
+      Map.merge(
+        %{
+          url: url,
+          cta: cta,
+          text: text
+        },
+        optional_params
+      )
+
+    %{cta_url: cta_url_config}
+  end
+
+  @doc """
+  For the parameter map given, read the optional keys and return a map
+  for those values.
+
+  The keys of the map are the keys supplied to this function but converted
+  to strings.
+
+  The key only exists on the returned map if a value for the key exists.
+  """
+  @spec read_optional_params(map, [:header | :footer]) :: %{optional(String.t()) => term}
+  def read_optional_params(params, keys) do
+    Enum.reduce(keys, %{}, fn key, acc ->
+      param_key = to_string(key)
+
+      if value = params[param_key], do: Map.put(acc, key, value), else: acc
+    end)
+  end
+
+  @impl true
+  @decorate with_span("DSL.Blocks.WhatsAppCallToAction.evaluate_incoming")
+  def evaluate_incoming(container, flow, block, context) do
+    context = %{context | last_block_uuid: block.uuid}
+
+    {:ok, container, flow, block, context}
+  end
+
+  @impl true
+  def evaluate_outgoing(_container, _flow, _block, _context, user_input) do
+    {:ok, user_input}
+  end
+end

--- a/lib/flow_runner/simulator.ex
+++ b/lib/flow_runner/simulator.ex
@@ -324,6 +324,51 @@ defmodule FlowRunner.Simulator do
   end
 
   def output_block(sim, %{
+        type: "Io.Turn.WhatsAppCallToAction",
+        config: %{
+          cta_url: %{
+            url: url,
+            cta: cta_resource_uuid,
+            text: text_resource_uuid
+          }
+        }
+      }) do
+    url = Expression.evaluate_as_string!(url, sim.context.vars, sim.callbacks_module)
+    text_resource = fetch_resource_by_uuid!(sim, text_resource_uuid)
+
+    [text] =
+      sim
+      |> fetch_resource_values(text_resource, "TEXT")
+      |> Enum.map(&resource_value_output(sim, &1))
+
+    cta_resource = fetch_resource_by_uuid!(sim, cta_resource_uuid)
+
+    [cta] =
+      sim
+      |> fetch_resource_values(cta_resource, "TEXT")
+      |> Enum.map(&resource_value_output(sim, &1))
+
+    debug_value = """
+    [DEBUG]
+    #{text.value}
+
+    A call-to-action button #{inspect(cta.value)} is sent to the phone, opening the URL #{inspect(url)}.
+
+    Note: it won't actually open in this simulator.
+    """
+
+    {{:message,
+      text: [
+        %Output{
+          mime_type: "text/plain",
+          raw_value: debug_value,
+          value: debug_value,
+          content_type: "TEXT"
+        }
+      ]}, sim}
+  end
+
+  def output_block(sim, %{
         type: "Io.Turn.ScheduleFlow",
         config: %{flow_id: flow_id, schedule_at: schedule_at_block}
       }) do

--- a/priv/fixtures/test/simulator/whatsapp_call_to_action_basic.flow
+++ b/priv/fixtures/test/simulator/whatsapp_call_to_action_basic.flow
@@ -1,0 +1,109 @@
+{
+  "name": "WhatsApp Call To Action",
+  "description": "WhatsApp interactive CTA URL message test",
+  "uuid": "d4b3810f-00d3-492e-92bd-75b0670d5eb9",
+  "flows": [
+    {
+      "uuid": "48da8ae9-0272-4ebf-8f30-fff28eeaf3e1",
+      "name": "WhatsApp Call To Action",
+      "label": null,
+      "last_modified": "2025-11-12T15:46:52.158515Z",
+      "interaction_timeout": 300,
+      "vendor_metadata": {},
+      "supported_modes": ["RICH_MESSAGING"],
+      "first_block_id": "e98b60d8-eaae-5fd4-a260-77a20549207d",
+      "exit_block_id": "",
+      "languages": [
+        {
+          "id": "57e46c33-bdb5-44cb-a707-11b89d1e6f7a",
+          "iso_639_3": "eng",
+          "label": "English",
+          "variant": null,
+          "bcp_47": null
+        }
+      ],
+      "blocks": [
+        {
+          "uuid": "e98b60d8-eaae-5fd4-a260-77a20549207d",
+          "name": "whatsapp_cta",
+          "label": null,
+          "semantic_label": null,
+          "tags": [],
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "code_generator": null,
+                      "condition": null,
+                      "meta": {"column": 3, "line": 2},
+                      "name": "Cta",
+                      "uuid": "181e9c45-45fd-5bb9-888a-00238f501ce4",
+                      "version": null
+                    },
+                    "card_item": {
+                      "meta": {"column": 5, "line": 4},
+                      "type": "whatsapp_cta",
+                      "whatsapp_cta": {}
+                    },
+                    "index": 0,
+                    "version": 2.0
+                  }
+                }
+              }
+            }
+          },
+          "ui_metadata": {"canvas_coordinates": {"x": 0, "y": 0}},
+          "type": "Io.Turn.WhatsAppCallToAction",
+          "config": {
+            "cta_url": {
+              "url": "https://example.com/products",
+              "text": "2ce61ee7-27a2-4d7f-b797-4282674e6e21",
+              "cta": "241daa6a-26ae-4cde-bcdf-07188e4a79d4"
+            }
+          },
+          "exits": [
+            {
+              "uuid": "47a40874-5531-45bc-b585-2f748a3905a8",
+              "name": "whatsapp_cta",
+              "destination_block": null,
+              "semantic_label": "",
+              "test": "",
+              "default": true,
+              "config": {},
+              "vendor_metadata": {}
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "uuid": "241daa6a-26ae-4cde-bcdf-07188e4a79d4",
+      "values": [
+        {
+          "language_id": "57e46c33-bdb5-44cb-a707-11b89d1e6f7a",
+          "content_type": "TEXT",
+          "mime_type": "text/plain",
+          "modes": ["RICH_MESSAGING"],
+          "value": "Visit our store"
+        }
+      ]
+    },
+    {
+      "uuid": "2ce61ee7-27a2-4d7f-b797-4282674e6e21",
+      "values": [
+        {
+          "language_id": "57e46c33-bdb5-44cb-a707-11b89d1e6f7a",
+          "content_type": "TEXT",
+          "mime_type": "text/plain",
+          "modes": ["RICH_MESSAGING"],
+          "value": "Tap the button below to browse our products"
+        }
+      ]
+    }
+  ],
+  "specification_version": "1.0.0-rc3"
+}

--- a/test/flow_runner/custom_blocks/whatsapp_call_to_action_test.exs
+++ b/test/flow_runner/custom_blocks/whatsapp_call_to_action_test.exs
@@ -1,0 +1,183 @@
+defmodule FlowRunner.CustomBlocks.WhatsAppCallToActionTest do
+  use ExUnit.Case, async: true
+
+  alias FlowRunner.CustomBlocks.WhatsAppCallToAction
+
+  describe "validate_config!/1" do
+    test "returns cta_url config with required url, cta and text parameters" do
+      config = %{
+        "cta_url" => %{
+          "url" => "https://example.com",
+          "cta" => "Visit our site",
+          "text" => "Tap the button below to learn more"
+        }
+      }
+
+      result = WhatsAppCallToAction.validate_config!(config)
+
+      assert result.cta_url.url == "https://example.com"
+      assert result.cta_url.cta == "Visit our site"
+      assert result.cta_url.text == "Tap the button below to learn more"
+      refute Map.has_key?(result.cta_url, :header)
+      refute Map.has_key?(result.cta_url, :footer)
+    end
+
+    test "returns cta_url config with optional header and footer parameters" do
+      config = %{
+        "cta_url" => %{
+          "url" => "https://example.com",
+          "cta" => "Visit our site",
+          "text" => "Tap the button below to learn more",
+          "header" => "Header text",
+          "footer" => "Footer text"
+        }
+      }
+
+      result = WhatsAppCallToAction.validate_config!(config)
+
+      assert result.cta_url.header == "Header text"
+      assert result.cta_url.footer == "Footer text"
+    end
+
+    test "raises error when cta_url key is missing" do
+      config = %{}
+
+      assert_raise FunctionClauseError, fn ->
+        WhatsAppCallToAction.validate_config!(config)
+      end
+    end
+
+    test "raises error when url parameter is missing" do
+      config = %{
+        "cta_url" => %{
+          "cta" => "Visit our site",
+          "text" => "Tap the button below to learn more"
+        }
+      }
+
+      assert_raise FunctionClauseError, fn ->
+        WhatsAppCallToAction.validate_config!(config)
+      end
+    end
+
+    test "raises error when cta parameter is missing" do
+      config = %{
+        "cta_url" => %{
+          "url" => "https://example.com",
+          "text" => "Tap the button below to learn more"
+        }
+      }
+
+      assert_raise FunctionClauseError, fn ->
+        WhatsAppCallToAction.validate_config!(config)
+      end
+    end
+
+    test "raises error when text parameter is missing" do
+      config = %{
+        "cta_url" => %{
+          "url" => "https://example.com",
+          "cta" => "Visit our site"
+        }
+      }
+
+      assert_raise FunctionClauseError, fn ->
+        WhatsAppCallToAction.validate_config!(config)
+      end
+    end
+  end
+
+  describe "read_optional_params/2" do
+    test "returns empty map when no optional parameters are present" do
+      params = %{"url" => "https://example.com"}
+      keys = [:header, :footer]
+
+      result = WhatsAppCallToAction.read_optional_params(params, keys)
+
+      assert result == %{}
+    end
+
+    test "returns map with only present optional parameters" do
+      params = %{
+        "url" => "https://example.com",
+        "footer" => "footer text"
+      }
+
+      keys = [:header, :footer]
+
+      result = WhatsAppCallToAction.read_optional_params(params, keys)
+
+      assert result == %{footer: "footer text"}
+    end
+
+    test "returns map with all optional parameters when present" do
+      params = %{
+        "header" => "header text",
+        "footer" => "footer text"
+      }
+
+      keys = [:header, :footer]
+
+      result = WhatsAppCallToAction.read_optional_params(params, keys)
+
+      assert result == %{header: "header text", footer: "footer text"}
+    end
+  end
+
+  describe "evaluate_incoming/4" do
+    test "updates last_block_uuid without waiting for user input" do
+      container = %{}
+      flow = %{}
+      block = %{uuid: "test-block-uuid"}
+
+      context = %{
+        last_block_uuid: "previous-uuid",
+        waiting_for_user_input: false
+      }
+
+      {:ok, returned_container, returned_flow, returned_block, returned_context} =
+        WhatsAppCallToAction.evaluate_incoming(container, flow, block, context)
+
+      assert returned_container == container
+      assert returned_flow == flow
+      assert returned_block == block
+      assert returned_context.last_block_uuid == "test-block-uuid"
+      assert returned_context.waiting_for_user_input == false
+    end
+
+    test "preserves other context fields while updating last_block_uuid" do
+      container = %{}
+      flow = %{}
+      block = %{uuid: "cta-block-uuid"}
+
+      context = %{
+        last_block_uuid: "old-uuid",
+        waiting_for_user_input: false,
+        some_other_field: "preserved_value",
+        another_field: 42
+      }
+
+      {:ok, _container, _flow, _block, returned_context} =
+        WhatsAppCallToAction.evaluate_incoming(container, flow, block, context)
+
+      assert returned_context.last_block_uuid == "cta-block-uuid"
+      assert returned_context.some_other_field == "preserved_value"
+      assert returned_context.another_field == 42
+    end
+  end
+
+  describe "evaluate_outgoing/5" do
+    test "returns user input unchanged" do
+      container = %{}
+      flow = %{}
+      block = %{}
+      context = %{}
+      user_input = %{type: "text", value: "some user response"}
+
+      {:ok, returned_input} =
+        WhatsAppCallToAction.evaluate_outgoing(container, flow, block, context, user_input)
+
+      assert returned_input == user_input
+    end
+  end
+end

--- a/test/flow_runner/simulator_test.exs
+++ b/test/flow_runner/simulator_test.exs
@@ -124,6 +124,24 @@ defmodule FlowRunner.SimulatorTest do
            |> has_value("Send location")
   end
 
+  test "simulator with whatsapp call to action" do
+    sim = Simulator.new(read_floip!("whatsapp_call_to_action_basic"))
+    {:end, _sim, outputs} = Simulator.start(sim)
+
+    text_output =
+      outputs
+      |> get_in([:message, :text])
+      |> with_content_type("TEXT")
+      |> List.first()
+
+    # Body text resource is rendered
+    assert text_output.value =~ "Tap the button below to browse our products"
+
+    # The call to action button text and URL are rendered
+    assert text_output.value =~ ~s(A call-to-action button "Visit our store" is sent to the phone)
+    assert text_output.value =~ ~s(opening the URL "https://example.com/products")
+  end
+
   test "simulator with whatsapp call permission request" do
     sim = Simulator.new(read_floip!("whatsapp_call_permission_request_basic"))
     {:waiting, _sim, outputs} = Simulator.start(sim)


### PR DESCRIPTION
## Summary

Adds a new `FlowRunner.CustomBlocks.WhatsAppCallToAction` block (`Io.Turn.WhatsAppCallToAction`) that maps to WhatsApp's [interactive CTA URL message type](https://developers.facebook.com/documentation/business-messaging/whatsapp/messages/interactive-cta-url-messages).

It is modeled on `WhatsAppSendFlow` with two key differences:
- `id` is replaced by `url`
- there is no `screen`

## Mapping to the Meta API

| Block config (`cta_url`) | Meta CTA URL field |
|---|---|
| `cta` | `action.parameters.display_text` |
| `url` | `action.parameters.url` |
| `text` | `body.text` |
| `header` (optional) | `header.text` |
| `footer` (optional) | `footer.text` |

`cta` and `text` are resource UUIDs; `url` is an expression string. Unlike send-flow, CTA URL messages do **not** wait for user input (they just open a link).

## Changes

- New block module `lib/flow_runner/custom_blocks/whatsapp_call_to_action.ex`
- Registered the block in `lib/flow_runner/blocks.ex`
- Added a simulator `output_block/2` clause in `lib/flow_runner/simulator.ex`
- Unit tests `test/flow_runner/custom_blocks/whatsapp_call_to_action_test.exs`
- Simulator fixture `priv/fixtures/test/simulator/whatsapp_call_to_action_basic.flow`
- Simulator integration test in `test/flow_runner/simulator_test.exs`

## Testing

`mix test` — 170 tests, 0 failures. Compiles cleanly with `--warnings-as-errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)