### PR TITLE
include .index in button response for dynamic lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ by adding `flow_runner` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:flow_runner, "~> 6.13.0"}
+    {:flow_runner, "~> 6.14.0"}
   ]
 end
 ```

--- a/lib/flow_runner/custom_blocks/dynamic_select_one_response.ex
+++ b/lib/flow_runner/custom_blocks/dynamic_select_one_response.ex
@@ -121,29 +121,33 @@ defmodule FlowRunner.CustomBlocks.DynamicSelectOneResponse do
   @impl true
   @decorate with_span("DSL.Blocks.DynamicSelectOneResponse.evaluate_outgoing")
   def evaluate_outgoing(container, flow, block, context, user_input) do
-    matched_option =
-      Enum.find(block.config.choices, fn
-        %{name: _name, test: test, prompt: _prompt} ->
-          FlowRunner.evaluate_expression_block(test, %{
-            "flow" => flow,
-            "block" => %{"response" => user_input}
-          })
+    matched =
+      block.config.choices
+      |> Enum.with_index()
+      |> Enum.find(fn {%{name: _name, test: test, prompt: _prompt}, _index} ->
+        FlowRunner.evaluate_expression_block(test, %{
+          "flow" => flow,
+          "block" => %{"response" => user_input}
+        })
       end)
 
-    if matched_option do
-      {:ok, resource} = FlowRunner.fetch_resource_by_uuid(container, matched_option.prompt)
+    case matched do
+      {matched_option, index} ->
+        {:ok, resource} = FlowRunner.fetch_resource_by_uuid(container, matched_option.prompt)
 
-      {:ok, resource_value} =
-        FlowRunner.fetch_resource_value(resource, context.language, context.mode, flow)
+        {:ok, resource_value} =
+          FlowRunner.fetch_resource_value(resource, context.language, context.mode, flow)
 
-      {:ok,
-       %{
-         "__value__" => matched_option.name,
-         "name" => matched_option.name,
-         "label" => resource_value.value
-       }}
-    else
-      {:invalid, "No choice tests evaluated to true."}
+        {:ok,
+         %{
+           "__value__" => matched_option.name,
+           "name" => matched_option.name,
+           "index" => index,
+           "label" => resource_value.value
+         }}
+
+      nil ->
+        {:invalid, "No choice tests evaluated to true."}
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule FlowRunner.MixProject do
   use Mix.Project
 
-  @version "6.13.0"
+  @version "6.14.0"
 
   def project do
     [

--- a/test/flow_runner/custom_blocks/dynamic_select_one_response_test.exs
+++ b/test/flow_runner/custom_blocks/dynamic_select_one_response_test.exs
@@ -32,7 +32,10 @@ defmodule FlowRunner.CustomBlocks.DynamicSelectOneResponseTest do
     flow = %Flow{languages: [%Language{id: @language_id, iso_639_3: "eng"}]}
 
     container = %Container{
-      resources: [resource("prompt-alpha", "Alpha label"), resource("prompt-bravo", "Bravo label")]
+      resources: [
+        resource("prompt-alpha", "Alpha label"),
+        resource("prompt-bravo", "Bravo label")
+      ]
     }
 
     {container, flow, block, %Context{language: "eng", mode: "TEXT"}}
@@ -45,10 +48,22 @@ defmodule FlowRunner.CustomBlocks.DynamicSelectOneResponseTest do
       {container, flow, block, context} = setup_block()
 
       assert {:ok, %{"name" => "Bravo", "index" => 1, "label" => "Bravo label"}} =
-               DynamicSelectOneResponse.evaluate_outgoing(container, flow, block, context, "Bravo")
+               DynamicSelectOneResponse.evaluate_outgoing(
+                 container,
+                 flow,
+                 block,
+                 context,
+                 "Bravo"
+               )
 
       assert {:ok, %{"name" => "Alpha", "index" => 0, "label" => "Alpha label"}} =
-               DynamicSelectOneResponse.evaluate_outgoing(container, flow, block, context, "Alpha")
+               DynamicSelectOneResponse.evaluate_outgoing(
+                 container,
+                 flow,
+                 block,
+                 context,
+                 "Alpha"
+               )
     end
 
     test "is invalid when no choice test matches the response" do

--- a/test/flow_runner/custom_blocks/dynamic_select_one_response_test.exs
+++ b/test/flow_runner/custom_blocks/dynamic_select_one_response_test.exs
@@ -3,7 +3,12 @@ defmodule FlowRunner.CustomBlocks.DynamicSelectOneResponseTest do
 
   alias FlowRunner.Context
   alias FlowRunner.CustomBlocks.DynamicSelectOneResponse
-  alias FlowRunner.Spec.{Block, Container, Flow, Language, Resource, ResourceValue}
+  alias FlowRunner.Spec.Block
+  alias FlowRunner.Spec.Container
+  alias FlowRunner.Spec.Flow
+  alias FlowRunner.Spec.Language
+  alias FlowRunner.Spec.Resource
+  alias FlowRunner.Spec.ResourceValue
 
   @language_id "11111111-1111-1111-1111-111111111111"
 

--- a/test/flow_runner/custom_blocks/dynamic_select_one_response_test.exs
+++ b/test/flow_runner/custom_blocks/dynamic_select_one_response_test.exs
@@ -1,0 +1,61 @@
+defmodule FlowRunner.CustomBlocks.DynamicSelectOneResponseTest do
+  use ExUnit.Case, async: true
+
+  alias FlowRunner.Context
+  alias FlowRunner.CustomBlocks.DynamicSelectOneResponse
+  alias FlowRunner.Spec.{Block, Container, Flow, Language, Resource, ResourceValue}
+
+  @language_id "11111111-1111-1111-1111-111111111111"
+
+  defp resource(uuid, value) do
+    %Resource{
+      uuid: uuid,
+      values: [
+        %ResourceValue{
+          language_id: @language_id,
+          content_type: "TEXT",
+          mime_type: "text/plain",
+          modes: ["TEXT"],
+          value: value
+        }
+      ]
+    }
+  end
+
+  defp setup_block do
+    choices = [
+      %{name: "Alpha", test: ~S(block.response = "Alpha"), prompt: "prompt-alpha"},
+      %{name: "Bravo", test: ~S(block.response = "Bravo"), prompt: "prompt-bravo"}
+    ]
+
+    block = %Block{type: "Io.Turn.DynamicSelectOneResponse", config: %{choices: choices}}
+    flow = %Flow{languages: [%Language{id: @language_id, iso_639_3: "eng"}]}
+
+    container = %Container{
+      resources: [resource("prompt-alpha", "Alpha label"), resource("prompt-bravo", "Bravo label")]
+    }
+
+    {container, flow, block, %Context{language: "eng", mode: "TEXT"}}
+  end
+
+  describe "evaluate_outgoing/5" do
+    # The picker journey routes by the selected position, so the response must
+    # carry the chosen choice's index (parity with the static SelectOneResponse).
+    test "returns the index of the selected choice" do
+      {container, flow, block, context} = setup_block()
+
+      assert {:ok, %{"name" => "Bravo", "index" => 1, "label" => "Bravo label"}} =
+               DynamicSelectOneResponse.evaluate_outgoing(container, flow, block, context, "Bravo")
+
+      assert {:ok, %{"name" => "Alpha", "index" => 0, "label" => "Alpha label"}} =
+               DynamicSelectOneResponse.evaluate_outgoing(container, flow, block, context, "Alpha")
+    end
+
+    test "is invalid when no choice test matches the response" do
+      {container, flow, block, context} = setup_block()
+
+      assert {:invalid, _reason} =
+               DynamicSelectOneResponse.evaluate_outgoing(container, flow, block, context, "Zulu")
+    end
+  end
+end


### PR DESCRIPTION
# Purpose

The static SelectOneResponse block returns the selected choice's index in its response (%{__value__, name, index, label}), but the runtime DynamicSelectOneResponse block did not — it returned only %{__value__, name, label}.

This matters for stateful journeys that build a dynamic list from a runtime collection (e.g. Turn's appointment slot picker, which lists available times from @slots.result.slots). Without the index, the journey can only get the chosen value/label back on the wire, which forces awkward workarounds when the displayed label differs from the value you actually need to act on. Since the source list persists in the session vars for the whole journey, returning the selected index lets a journey resolve the pick straight back to the original entry by position — @source_list[picked.index] — with no value-on-the-wire gymnastics.

This change brings DynamicSelectOneResponse to parity with SelectOneResponse.

# Approach

Mirror the static SelectOneResponse.evaluate_outgoing/5 exactly: iterate the choices with Enum.with_index(), find the matching choice (its test is truthy for the response), and include "index" => index in the returned response map alongside __value__, name, and label. No format change to choices/exits; purely an additive field on the response.

- lib/flow_runner/custom_blocks/dynamic_select_one_response.ex — Enum.find → Enum.with_index() |> Enum.find, if → case, add "index" => index to the {:ok, ...} map.
- New test/flow_runner/custom_blocks/dynamic_select_one_response_test.exs — covers evaluate_outgoing/5 returning the correct index for the selected choice (0 and 1) and the {:invalid, _} no-match path.
- Version bumped 6.13.0 → 6.14.0 (mix.exs) and the install snippet in README.md updated to match, per the publish checklist.

# Learning

Followed the existing SelectOneResponse.evaluate_outgoing/5 (lib/flow_runner/spec/blocks/select_one_response.ex) as the reference — it already does Enum.with_index() and returns "index", documented as "Map with __value__, name, index, and label of the selected choice." This just extends the same contract to the dynamic block.